### PR TITLE
Fixed build error of httpx tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,9 @@ ENV PATH="${PATH}:${GOPATH}/bin"
 # Download Go packages
 RUN go get -u github.com/tomnomnom/assetfinder github.com/hakluke/hakrawler
 
-RUN GO111MODULE=on go get -u -v github.com/projectdiscovery/httpx/cmd/httpx
+RUN GO111MODULE=on go get -v github.com/projectdiscovery/httpx/cmd/httpx
 
-RUN GO111MODULE=on go get -u -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder \
+RUN GO111MODULE=on go get -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder \
     github.com/projectdiscovery/nuclei/v2/cmd/nuclei \
     github.com/lc/gau \
     github.com/projectdiscovery/naabu/cmd/naabu

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.8'
 
 services:
     db:

--- a/docker-compose.setup.yml
+++ b/docker-compose.setup.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.8'
 services:
   certs:
     build: ./certs
@@ -12,5 +12,3 @@ services:
       - CITY=${CITY:-City}
     volumes:
       - ./secrets/certs:/certs:rw
-
-


### PR DESCRIPTION
Some tools (e.g. httpx) require gologger in version 1.0.1 and use the
the function gologger.Errorf, but in the Dockerfile the "-u" flag
instructs get to use the network to update the named packages and
their dependencies. Thus, gologger is updated to v1.1.2 where the
function gologger.Errorf seems to be removed (see #303).

The removal of the "-u" flag fixes the build error.