### PR TITLE
Fix typo 'succesful' -> 'successful'

### DIFF
--- a/dashboard/templates/dashboard/index.html
+++ b/dashboard/templates/dashboard/index.html
@@ -334,7 +334,7 @@ Dashboard
 								{% elif item.scan_status == 1 %}
 								<span class="shadow-none badge badge-info">{% include 'base/_items/progress_spin.html' %}Scanning</span>
 								{% elif item.scan_status == 2 %}
-								<span class="shadow-none badge badge-success">Succesful</span>
+								<span class="shadow-none badge badge-success">Successful</span>
 								{% elif item.scan_status == 3 %}
 								<span class="shadow-none badge badge-danger">Aborted</span>
 								{% else %}

--- a/startScan/templates/startScan/history.html
+++ b/startScan/templates/startScan/history.html
@@ -62,7 +62,7 @@ Scan History
 									{% elif scan_history.scan_status == 1 %}
 									<span class="shadow-none badge badge-primary">{% include 'base/_items/progress_spin.html' %}Scanning</span>
 									{% elif scan_history.scan_status == 2 %}
-									<span class="shadow-none badge badge-success p-2">Succesful</span>
+									<span class="shadow-none badge badge-success p-2">Successful</span>
 									{% elif scan_history.scan_status == 3 %}
 									<span class="shadow-none badge badge-danger">Aborted</span>
 									{% else %}


### PR DESCRIPTION
This MR fixes a typo on the dashboard and the scan history. It should be 'Successful' with double s instead of 'Succesful' (https://www.dictionary.com/browse/successful).
