### PR TITLE
Fix docker build with github actions

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -16,7 +16,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set Docker image name
-        run: echo "::set-env name=IMAGE_ID::$(echo -n '${{ github.repository }}/${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')"
+        run: |
+          echo "IMAGE_ID=$(echo -n '${{ github.repository }}/${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set Docker image name
-        run: echo "::set-env name=IMAGE_ID::$(echo -n '${{ github.repository }}/${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')"
+        run: |
+          echo "IMAGE_ID=$(echo -n '${{ github.repository }}/${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v1


### PR DESCRIPTION
Remove github actions deprecated set-env command: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/