### PR TITLE
Add EyeWitness to create screenshots

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,9 @@ WORKDIR /app
 # Copy source code
 COPY . /app/
 
+RUN git clone https://github.com/FortyNorthSecurity/EyeWitness.git /app/tools/EyeWitness/
+RUN sh /app/tools/EyeWitness/Python/setup/setup.sh
+
 RUN chmod +x /app/tools/get_dirs.sh
 RUN chmod +x /app/tools/get_urls.sh
 RUN chmod +x /app/tools/takeover.sh

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,8 +22,6 @@ services:
         command: python3 manage.py runserver 0.0.0.0:8000
         environment:
             - DEBUG=1
-        volumes:
-          - .:/app
         ports:
           - "8000:8000"
         depends_on:
@@ -45,6 +43,8 @@ services:
             - redis
         networks:
             - rengine_network
+        volumes:
+            - ./tools/scan_results:/app/tools/scan_results
     celery-beat:
         build: .
         command: celery -A reNgine beat -l INFO --scheduler django_celery_beat.schedulers:DatabaseScheduler

--- a/tools/scan_results/.gitignore
+++ b/tools/scan_results/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
Implemented ability to use the EyeWitness to create screenshots.

Usage Example in scanEngine:

```yaml
visual_identification:
    uses_tool: eyewitness
    port: xlarge
    thread: 2
    http_timeout: 3000
```

if delete the uses_tool key, aquatone will be used by default.

