### PR TITLE
Random UserAgent for HTTPX

### DIFF
--- a/reNgine/tasks.py
+++ b/reNgine/tasks.py
@@ -305,7 +305,7 @@ def doScan(domain_id, scan_history_id, scan_type, engine_type):
         # background thread later
         httpx_results_file = results_dir + current_scan_dir + '/httpx.json'
 
-        httpx_command = 'cat {} | httpx -cdn -json -o {} -threads 100'.format(
+        httpx_command = 'cat {} | httpx -random-agent -cdn -json -o {} -threads 100'.format(
             subdomain_scan_results_file, httpx_results_file)
         os.system(httpx_command)
 


### PR DESCRIPTION
Randomizing UA for added protection from being easily blocked by a WAF/CDN or if a page returns a different status code depending on UA.

Currently it would be...
```
User-Agent: httpx - Open-source project (github.com/projectdiscovery/httpx)
```
Now it might be...
```
User-Agent: Mozilla/5.0 (Linux; U; Android 1.5; en-us; SPH-M900 Build/CUPCAKE) AppleWebKit/528.5  (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
```