### PR TITLE
[Security Fix] Update Django version to 3.2.5

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -3,7 +3,7 @@ beautifulsoup4==4.9.3
 celery==5.1.1
 degoogle==1.0.1
 discord-webhook==0.14.0
-Django==3.2.4
+Django==3.2.5
 django-ace==1.0.11
 django-celery-beat==2.2.0
 django-login-required-middleware==0.6.1


### PR DESCRIPTION
**Vulnerability:** Django SQL Injection
**CVE-ID:** CVE-2021-35042
**CWE-ID:** CWE-89
**CVSS Score:** 7.3
**Vector String:** CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L
**Description:** Django 3.1.x before 3.1.13 and 3.2.x before 3.2.5 allows QuerySet.order_by SQL injection if order_by is untrusted input from a client of a web application.