### PR TITLE
Fix #529

### DIFF
--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -1337,6 +1337,8 @@ def vulnerability_scan(
                             vulnerability.reference = json_st['info']['reference']
                         if 'matched' in json_st:
                             vulnerability.http_url = json_st['matched']
+                        if 'matched-at' in json_st:
+                            vulnerability.http_url = json_st['matched-at']
                         if 'templateID' in json_st:
                             vulnerability.template_used = json_st['templateID']
                         if 'description' in json_st:

--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -1335,7 +1335,7 @@ def vulnerability_scan(
                             vulnerability.description = json_st['info']['description']
                         if 'reference' in json_st['info']:
                             vulnerability.reference = json_st['info']['reference']
-                        if 'matched' in json_st:
+                        if 'matched' in json_st:  # TODO remove in rengine 1.1. 'matched' isn't used in nuclei 2.5.3
                             vulnerability.http_url = json_st['matched']
                         if 'matched-at' in json_st:
                             vulnerability.http_url = json_st['matched-at']


### PR DESCRIPTION
Nuclei returns the response to stdout:
`{"template-id":"tech-detect","info":{"name":"Wappalyzer Technology Detection","author":["hakluke"],"tags":["tech"],"reference":null,"severity":"info"},"matcher-name":"nginx","type":"http","host":"https://example.com:443","matched-at":"https://example.com:443","timestamp":"2021-10-31T09:39:47.1571248Z","curl-command":"curl -X 'GET' -d '' -H 'Accept: */*' -H 'Accept-Language: en' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1944.0 Safari/537.36' 'https://example.com'"}`

It needs to read host_url from matched-at, not from matched.