### PR TITLE
Dirsearch stopped using --recursion-depth

### DIFF
--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -906,7 +906,6 @@ def directory_brute(task, domain, yaml_configuration, results_dir, activity_id):
             dirsearch_command += ' -exclude-texts {}'.format(exclude_text)
 
         # check if recursive strategy is set to on
-
         if RECURSIVE_LEVEL in yaml_configuration[DIR_FILE_SEARCH]:
             dirsearch_command += ' --max-recursion-depth {}'.format(yaml_configuration[DIR_FILE_SEARCH][RECURSIVE_LEVEL])
 

--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -908,10 +908,7 @@ def directory_brute(task, domain, yaml_configuration, results_dir, activity_id):
         # check if recursive strategy is set to on
 
         if RECURSIVE_LEVEL in yaml_configuration[DIR_FILE_SEARCH]:
-            dirsearch_command += ' --recursion-depth {}'.format(yaml_configuration[DIR_FILE_SEARCH][RECURSIVE_LEVEL])
-
-        if RECURSIVE_LEVEL in yaml_configuration[DIR_FILE_SEARCH]:
-            dirsearch_command += ' --recursion-depth {}'.format(yaml_configuration[DIR_FILE_SEARCH][RECURSIVE_LEVEL])
+            dirsearch_command += ' --max-recursion-depth {}'.format(yaml_configuration[DIR_FILE_SEARCH][RECURSIVE_LEVEL])
 
         # proxy
         proxy = get_random_proxy()


### PR DESCRIPTION
In latest build of dirsearch, they have stopped using --recursion-depth syntax, instead they started using --max-recursion-depth.
I noticed this when i enabled recursive option in yaml engine file and faced an error of dirsearch.py: error: no such option: --recursion-depth upon researching i got to know that still in their documentation they have mentioned to use  --recursion-depth but if i download their latest build and use tool help page shows me to use --max-recursion-depth 