### PR TITLE
Adding GO11MODULE=on to the dockerfile

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -9,7 +9,8 @@ LABEL \
 
 # Environment Variables
 ENV DEBIAN_FRONTEND="noninteractive" \
-    DATABASE="postgres"
+    DATABASE="postgres" \
+    GO11MODULE="on"
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
Fixes the `web/Dockerfile` build error: `go: cannot use path@version syntax in GOPATH mode` when using the docker-compose up command.