### PR TITLE
use custom ports from .env for Postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,12 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_PORT=${POSTGRES_PORT}
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT}:${POSTGRES_PORT}
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     networks:
       - rengine_network
+    command: -p ${POSTGRES_PORT}
 
   redis:
     image: "redis:alpine"


### PR DESCRIPTION
The 'POSTGRES_PORT' defined in the '.env' file was not used in the docker_compose.yml for custom ports.