### PR TITLE
Improve Docker setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ username:		## Generate Username (Use only after make up).
 	${COMPOSE_PREFIX_CMD} docker compose ${COMPOSE_ALL_FILES} exec web python3 manage.py createsuperuser
 
 pull:			## Pull Docker images.
-	docker login docker.pkg.github.com
 	${COMPOSE_PREFIX_CMD} docker compose ${COMPOSE_ALL_FILES} pull
 
 down:			## Down all services.

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ certs:		    ## Generate certificates.
 setup:			## Generate certificates.
 	@make certs
 
-up:				## Build and start all services.
-	${COMPOSE_PREFIX_CMD} docker compose ${COMPOSE_ALL_FILES} up -d --build ${SERVICES}
+up:				## Start all services.
+	${COMPOSE_PREFIX_CMD} docker compose ${COMPOSE_ALL_FILES} up -d ${SERVICES}
 
 build:			## Build all services.
 	${COMPOSE_PREFIX_CMD} docker compose ${COMPOSE_ALL_FILES} build ${SERVICES}

--- a/Makefile
+++ b/Makefile
@@ -13,45 +13,45 @@ SERVICES          := db web proxy redis celery celery-beat tor
 .PHONY: setup certs up build username pull down stop restart rm logs
 
 certs:		    ## Generate certificates.
-	@${COMPOSE_PREFIX_CMD} docker-compose -f docker-compose.setup.yml run --rm certs
+	@${COMPOSE_PREFIX_CMD} docker compose -f docker-compose.setup.yml run --rm certs
 
 setup:			## Generate certificates.
 	@make certs
 
 up:				## Build and start all services.
-	${COMPOSE_PREFIX_CMD} docker-compose ${COMPOSE_ALL_FILES} up -d --build ${SERVICES}
+	${COMPOSE_PREFIX_CMD} docker compose ${COMPOSE_ALL_FILES} up -d --build ${SERVICES}
 
 build:			## Build all services.
-	${COMPOSE_PREFIX_CMD} docker-compose ${COMPOSE_ALL_FILES} build ${SERVICES}
+	${COMPOSE_PREFIX_CMD} docker compose ${COMPOSE_ALL_FILES} build ${SERVICES}
 
 username:		## Generate Username (Use only after make up).
-	${COMPOSE_PREFIX_CMD} docker-compose ${COMPOSE_ALL_FILES} exec web python3 manage.py createsuperuser
+	${COMPOSE_PREFIX_CMD} docker compose ${COMPOSE_ALL_FILES} exec web python3 manage.py createsuperuser
 
 pull:			## Pull Docker images.
 	docker login docker.pkg.github.com
-	${COMPOSE_PREFIX_CMD} docker-compose ${COMPOSE_ALL_FILES} pull
+	${COMPOSE_PREFIX_CMD} docker compose ${COMPOSE_ALL_FILES} pull
 
 down:			## Down all services.
-	${COMPOSE_PREFIX_CMD} docker-compose ${COMPOSE_ALL_FILES} down
+	${COMPOSE_PREFIX_CMD} docker compose ${COMPOSE_ALL_FILES} down
 
 stop:			## Stop all services.
-	${COMPOSE_PREFIX_CMD} docker-compose ${COMPOSE_ALL_FILES} stop ${SERVICES}
+	${COMPOSE_PREFIX_CMD} docker compose ${COMPOSE_ALL_FILES} stop ${SERVICES}
 
 restart:		## Restart all services.
-	${COMPOSE_PREFIX_CMD} docker-compose ${COMPOSE_ALL_FILES} restart ${SERVICES}
+	${COMPOSE_PREFIX_CMD} docker compose ${COMPOSE_ALL_FILES} restart ${SERVICES}
 
 rm:				## Remove all services containers.
-	${COMPOSE_PREFIX_CMD} docker-compose $(COMPOSE_ALL_FILES) rm -f ${SERVICES}
+	${COMPOSE_PREFIX_CMD} docker compose $(COMPOSE_ALL_FILES) rm -f ${SERVICES}
 
 logs:			## Tail all logs with -n 1000.
-	${COMPOSE_PREFIX_CMD} docker-compose $(COMPOSE_ALL_FILES) logs --follow --tail=1000 ${SERVICES}
+	${COMPOSE_PREFIX_CMD} docker compose $(COMPOSE_ALL_FILES) logs --follow --tail=1000 ${SERVICES}
 
 images:			## Show all Docker images.
-	${COMPOSE_PREFIX_CMD} docker-compose $(COMPOSE_ALL_FILES) images ${SERVICES}
+	${COMPOSE_PREFIX_CMD} docker compose $(COMPOSE_ALL_FILES) images ${SERVICES}
 
 prune:			## Remove containers and delete volume data.
 	@make stop && make rm && docker volume prune -f
 
 help:			## Show this help.
-	@echo "Make application docker images and manage containers using docker-compose files."
+	@echo "Make application docker images and manage containers using docker compose files."
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m (default: help)\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,6 +25,7 @@ services:
   celery:
     build:
       context: ./web
+    image: yogeshojha/rengine:master
     restart: always
     entrypoint: /usr/src/app/celery-entrypoint.sh
     command: watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine worker --autoscale=${MAX_CONCURRENCY},${MIN_CONCURRENCY} -l INFO
@@ -53,6 +54,7 @@ services:
 
   celery-beat:
     build: ./web
+    image: yogeshojha/rengine:master
     entrypoint: /usr/src/app/beat-entrypoint.sh
     command: celery -A reNgine beat -l INFO --scheduler django_celery_beat.schedulers:DatabaseScheduler
     environment:
@@ -84,7 +86,7 @@ services:
       context: ./web
     entrypoint: /usr/src/app/entrypoint.sh
     restart: always
-    image: docker.pkg.github.com/yogeshojha/rengine/rengine:latest
+    image: yogeshojha/rengine:master
     environment:
       - DEBUG=1
       - CELERY_BROKER=redis://redis:6379/0

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,13 +18,12 @@ services:
 
   redis:
     image: "redis:alpine"
-    hostname: redis
+    restart: always
     networks:
       - rengine_network
 
   celery:
-    build:
-      context: ./web
+    build: ./web
     image: yogeshojha/rengine:master
     restart: always
     entrypoint: /usr/src/app/celery-entrypoint.sh
@@ -55,10 +54,9 @@ services:
   celery-beat:
     build: ./web
     image: yogeshojha/rengine:master
+    restart: always
     entrypoint: /usr/src/app/beat-entrypoint.sh
     command: celery -A reNgine beat -l INFO --scheduler django_celery_beat.schedulers:DatabaseScheduler
-    environment:
-      - DEBUG=1
     depends_on:
       - celery
     environment:
@@ -82,8 +80,7 @@ services:
       - rengine_network
 
   web:
-    build:
-      context: ./web
+    build: ./web
     entrypoint: /usr/src/app/entrypoint.sh
     restart: always
     image: yogeshojha/rengine:master

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_PORT=${POSTGRES_PORT}
-    ports:
-      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     networks:
@@ -18,13 +16,13 @@ services:
 
   redis:
     image: "redis:alpine"
+    restart: always
     hostname: redis
     networks:
       - rengine_network
 
   celery:
-    build:
-      context: ./web
+    build: ./web
     image: yogeshojha/rengine:master
     restart: always
     entrypoint: /usr/src/app/celery-entrypoint.sh
@@ -56,6 +54,7 @@ services:
   celery-beat:
     build: ./web
     image: yogeshojha/rengine:master
+    restart: always
     entrypoint: /usr/src/app/beat-entrypoint.sh
     command: celery -A reNgine beat -l INFO --scheduler django_celery_beat.schedulers:DatabaseScheduler
     environment:
@@ -81,8 +80,7 @@ services:
       - rengine_network
 
   web:
-    build:
-      context: ./web
+    build: ./web
     entrypoint: /usr/src/app/entrypoint.sh
     restart: always
     image: yogeshojha/rengine:master
@@ -107,14 +105,10 @@ services:
       - nuclei_templates:/root/nuclei-templates
       - tool_config:/root/.config
       - static_volume:/usr/src/app/staticfiles/
-    ports:
-      - "8000:8000"
     depends_on:
       - db
       - celery
       - celery-beat
-    networks:
-      - rengine_network
     networks:
       rengine_network:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
   celery:
     build:
       context: ./web
+    image: yogeshojha/rengine:master
     restart: always
     entrypoint: /usr/src/app/celery-entrypoint.sh
     command: watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine worker --autoscale=${MAX_CONCURRENCY},${MIN_CONCURRENCY} -l INFO
@@ -54,6 +55,7 @@ services:
 
   celery-beat:
     build: ./web
+    image: yogeshojha/rengine:master
     entrypoint: /usr/src/app/beat-entrypoint.sh
     command: celery -A reNgine beat -l INFO --scheduler django_celery_beat.schedulers:DatabaseScheduler
     environment:
@@ -83,7 +85,7 @@ services:
       context: ./web
     entrypoint: /usr/src/app/entrypoint.sh
     restart: always
-    image: docker.pkg.github.com/yogeshojha/rengine/rengine:latest
+    image: yogeshojha/rengine:master
     environment:
       - DEBUG=0
       - CELERY_BROKER=redis://redis:6379/0

--- a/install.sh
+++ b/install.sh
@@ -60,22 +60,6 @@ else
   tput setaf 2; echo "Docker installed!!!"
 fi
 
-
-echo " "
-tput setaf 4;
-echo "#########################################################################"
-echo "Installing docker-compose"
-echo "#########################################################################"
-if [ -x "$(command -v docker-compose)" ]; then
-  tput setaf 2; echo "docker-compose already installed, skipping."
-else
-  curl -L "https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-  chmod +x /usr/local/bin/docker-compose
-  ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
-  tput setaf 2; echo "docker-compose installed!!!"
-fi
-
-
 echo " "
 tput setaf 4;
 echo "#########################################################################"

--- a/make.bat
+++ b/make.bat
@@ -9,8 +9,8 @@ set SERVICES           = db web proxy redis celery celery-beat
 if "%1" == "certs" docker compose -f docker-compose.setup.yml run --rm certs
 :: Generate certificates.
 if "%1" == "setup" docker compose -f docker-compose.setup.yml run --rm certs
-:: Build and start all services.
-if "%1" == "up" docker compose %COMPOSE_ALL_FILES% up -d --build %SERVICES%
+:: Start all services.
+if "%1" == "up" docker compose %COMPOSE_ALL_FILES% up -d %SERVICES%
 :: Build all services.
 if "%1" == "build" docker compose %COMPOSE_ALL_FILES% build %SERVICES%
 :: Generate Username (Use only after make up).

--- a/make.bat
+++ b/make.bat
@@ -16,7 +16,7 @@ if "%1" == "build" docker compose %COMPOSE_ALL_FILES% build %SERVICES%
 :: Generate Username (Use only after make up).
 if "%1" == "username" docker compose %COMPOSE_ALL_FILES% exec web python manage.py createsuperuser
 :: Pull Docker images.
-if "%1" == "pull" docker login docker.pkg.github.com & docker compose %COMPOSE_ALL_FILES% pull
+if "%1" == "pull" docker compose %COMPOSE_ALL_FILES% pull
 :: Down all services.
 if "%1" == "down" docker compose %COMPOSE_ALL_FILES% down
 :: Stop all services.

--- a/make.bat
+++ b/make.bat
@@ -6,30 +6,30 @@ set COMPOSE_ALL_FILES  = -f docker-compose.yml
 set SERVICES           = db web proxy redis celery celery-beat
 
 :: Generate certificates.
-if "%1" == "certs" docker-compose -f docker-compose.setup.yml run --rm certs
+if "%1" == "certs" docker compose -f docker-compose.setup.yml run --rm certs
 :: Generate certificates.
-if "%1" == "setup" docker-compose -f docker-compose.setup.yml run --rm certs
+if "%1" == "setup" docker compose -f docker-compose.setup.yml run --rm certs
 :: Build and start all services.
-if "%1" == "up" docker-compose %COMPOSE_ALL_FILES% up -d --build %SERVICES%
+if "%1" == "up" docker compose %COMPOSE_ALL_FILES% up -d --build %SERVICES%
 :: Build all services.
-if "%1" == "build" docker-compose %COMPOSE_ALL_FILES% build %SERVICES%
+if "%1" == "build" docker compose %COMPOSE_ALL_FILES% build %SERVICES%
 :: Generate Username (Use only after make up).
-if "%1" == "username" docker-compose %COMPOSE_ALL_FILES% exec web python manage.py createsuperuser
+if "%1" == "username" docker compose %COMPOSE_ALL_FILES% exec web python manage.py createsuperuser
 :: Pull Docker images.
-if "%1" == "pull" docker login docker.pkg.github.com & docker-compose %COMPOSE_ALL_FILES% pull
+if "%1" == "pull" docker login docker.pkg.github.com & docker compose %COMPOSE_ALL_FILES% pull
 :: Down all services.
-if "%1" == "down" docker-compose %COMPOSE_ALL_FILES% down
+if "%1" == "down" docker compose %COMPOSE_ALL_FILES% down
 :: Stop all services.
-if "%1" == "stop" docker-compose %COMPOSE_ALL_FILES% stop %SERVICES%
+if "%1" == "stop" docker compose %COMPOSE_ALL_FILES% stop %SERVICES%
 :: Restart all services.
-if "%1" == "restart" docker-compose %COMPOSE_ALL_FILES% restart %SERVICES%
+if "%1" == "restart" docker compose %COMPOSE_ALL_FILES% restart %SERVICES%
 :: Remove all services containers.
-if "%1" == "rm" docker-compose %COMPOSE_ALL_FILES% rm -f %SERVICES%
+if "%1" == "rm" docker compose %COMPOSE_ALL_FILES% rm -f %SERVICES%
 :: Tail all logs with -n 1000.
-if "%1" == "logs" docker-compose %COMPOSE_ALL_FILES% logs --follow --tail=1000 %SERVICES%
+if "%1" == "logs" docker compose %COMPOSE_ALL_FILES% logs --follow --tail=1000 %SERVICES%
 :: Show all Docker images.
-if "%1" == "images" docker-compose %COMPOSE_ALL_FILES% images %SERVICES%
+if "%1" == "images" docker compose %COMPOSE_ALL_FILES% images %SERVICES%
 :: Remove containers and delete volume data.
-if "%1" == "prune" docker-compose %COMPOSE_ALL_FILES% stop %SERVICES% & docker-compose %COMPOSE_ALL_FILES% rm -f %SERVICES% & docker volume prune -f
+if "%1" == "prune" docker compose %COMPOSE_ALL_FILES% stop %SERVICES% & docker compose %COMPOSE_ALL_FILES% rm -f %SERVICES% & docker volume prune -f
 :: Show this help.
-if "%1" == "help" @echo Make application docker images and manage containers using docker-compose files only for windows.
+if "%1" == "help" @echo Make application docker images and manage containers using docker compose files only for windows.


### PR DESCRIPTION
This PR introduces some improvements regarding the Docker setup.

I tried to run reNgine in a newly created VM and noticed a few things that would allow a user to get reNgine up and running much quicker, which are:

- Drop `docker-compose` (v1): Since Docker Engine 20.10.13 the new Docker Compose v2 CLI is available by default (see https://docs.docker.com/engine/release-notes/#201013). It's was available in Docker Desktop much earlier and is default since 4.8.0. Hence there's no need for manually installing `docker-compose` (v1). `docker-compose-plugin` is also installed automatically by get.docker.com.
- Use Docker images from Docker Hub: Since the Docker images on GitHub (see https://github.com/yogeshojha/rengine/pkgs/container/rengine%2Frengine) hasn't been updated, but the ones on Docker Hub have (see https://hub.docker.com/r/yogeshojha/rengine/tags), we should use them
- Don't enforce building images: Because we're can use the pre-built images from Docker Hub, we shouldn't force a user to build them locally. Explicitly building with `make build` is still possible of course.
- General cleanups of Dockerfiles:
  - Remove unnecessary explicit `context` in build configuration
  - Remove duplicate `networks` specification
  - Remove publicly exposed ports of internal services in production environment
  - Always restart services

I am running these changes on my local machine without any issues :)