### PR TITLE
update ssl_ecdh_curve param

### DIFF
--- a/config/nginx/rengine.conf
+++ b/config/nginx/rengine.conf
@@ -46,7 +46,7 @@ server {
     ssl_prefer_server_ciphers                       on;                                                 # Specifies that server ciphers should be preferred over client ciphers.
 
     # ssl_dhparam                                     /etc/ssl/private/private/dh4096.pem;                # Diffie-Hellman server params with 4096 bits (generated using `openssl dhparam 4096 -out /etc/ssl/private/private/dh4096.pem`).
-    ssl_ecdh_curve                                  sect571r1:secp521r1:brainpoolP512r1:secp384r1;      # Elliptic Curve Diffie-Hellman server params.
+    ssl_ecdh_curve                                  secp384r1:X25519:prime256v1;                        # Elliptic Curve Diffie-Hellman server params.
 
     ssl_session_cache                               shared:SSL:10m;                                     # Create a shared cache able to store about 80000 sessions (about 4000 for 1MB storage).
     ssl_session_timeout                             5m;                                                 # Timeout before session to be dropped.


### PR DESCRIPTION
The current `ssl_ecdh_curve` parameter value in `rengine.conf` causes a start failure for the proxy. With this new value, the proxy starts properly.