### PR TITLE
Fix python not found in PATH in make.bat

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -14,7 +14,7 @@ if "%1" == "up" docker-compose %COMPOSE_ALL_FILES% up -d --build %SERVICES%
 :: Build all services.
 if "%1" == "build" docker-compose %COMPOSE_ALL_FILES% build %SERVICES%
 :: Generate Username (Use only after make up).
-if "%1" == "username" docker-compose %COMPOSE_ALL_FILES% exec web python manage.py createsuperuser
+if "%1" == "username" docker-compose %COMPOSE_ALL_FILES% exec web python3 manage.py createsuperuser
 :: Pull Docker images.
 if "%1" == "pull" docker login docker.pkg.github.com & docker-compose %COMPOSE_ALL_FILES% pull
 :: Down all services.


### PR DESCRIPTION
- Fix python3 not found in path for username command in make.bat

**Issue Info:**
```batch
C:\Users\user\Documents\rengine>make username
OCI runtime exec failed: exec failed: unable to start container process: exec: "python": executable file not found in $PATH: unknown
```

**Issue describe:**
python3 was registered to `python` in make.bat for the username command,
fix it to `python3` which is in `PATH` due to newer linux distro in docker