### PR TITLE
remove duplicate networks mapping key

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,10 +113,6 @@ services:
       - celery-beat
     networks:
       - rengine_network
-    networks:
-      rengine_network:
-        aliases:
-          - rengine
 
   tor:
     image: peterdavehello/tor-socks-proxy


### PR DESCRIPTION
Remove duplicate networks mapping key from the docker-compose.yml in the `web` section