### PR TITLE
Update go to v 19.4

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -42,9 +42,9 @@ RUN apt update -y && apt install -y  --no-install-recommends \
 
 
 # Download and install go 1.18
-RUN wget https://golang.org/dl/go1.18.2.linux-amd64.tar.gz
-RUN tar -xvf go1.18.2.linux-amd64.tar.gz
-RUN rm go1.18.2.linux-amd64.tar.gz
+RUN wget https://golang.org/dl/go1.19.4.linux-amd64.tar.gz
+RUN tar -xvf go1.19.4.linux-amd64.tar.gz
+RUN rm go1.19.4.linux-amd64.tar.gz
 RUN mv go /usr/local
 
 # Download geckodriver


### PR DESCRIPTION
Replace go1.18.2.linux-amd64.tar.gz with go1.19.4.linux-amd64.tar.gz to resolve httpx/nuclei install issue.