### PR TITLE
Fixes required to get install script working

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -42,9 +42,9 @@ RUN apt update -y && apt install -y  --no-install-recommends \
 
 
 # Download and install go 1.18
-RUN wget https://golang.org/dl/go1.18.2.linux-amd64.tar.gz
-RUN tar -xvf go1.18.2.linux-amd64.tar.gz
-RUN rm go1.18.2.linux-amd64.tar.gz
+RUN wget https://golang.org/dl/go1.20.linux-amd64.tar.gz
+RUN tar -xvf go1.20.linux-amd64.tar.gz
+RUN rm go1.20.linux-amd64.tar.gz
 RUN mv go /usr/local
 
 # Download geckodriver

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,6 +1,6 @@
 argh
 beautifulsoup4==4.9.3
-celery==5.1.2
+celery==5.2.7
 degoogle==1.0.1
 discord-webhook==0.14.0
 Django==3.2.4


### PR DESCRIPTION
Update celery version to 5.2.7 in requirements.txt
Update go version to 1.20 in Dockerfile

These changes are required for install.sh to complete on Ubuntu 22.04.1 LTS (GNU/Linux 5.15.0-66-generic x86_64) (digital ocean droplet).

Note: Saw some warning/maybe error related to whatisport (or similar) pypi package. Will investigate at some point.