### PR TITLE
Amass v3 Installation/Update Issue

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -75,7 +75,7 @@ RUN GO111MODULE=on go install -v -v github.com/bp0lr/gauplus@latest
 
 RUN GO111MODULE=on go install -v github.com/jaeles-project/gospider@latest
 
-RUN go install -v github.com/OWASP/Amass/v3/...@latest
+RUN go install -v github.com/owasp-amass/amass/v3/...@latest
 
 RUN go install -v github.com/ffuf/ffuf@latest
 

--- a/web/fixtures/external_tools.yaml
+++ b/web/fixtures/external_tools.yaml
@@ -104,8 +104,8 @@
     github_url: https://github.com/OWASP/Amass
     license_url: https://github.com/OWASP/Amass/blob/master/LICENSE
     version_lookup_command: amass -version
-    update_command: go install -v github.com/OWASP/Amass/v3/...@latest
-    install_command: go install -v github.com/OWASP/Amass/v3/...@latest
+    update_command: go install -v github.com/owasp-amass/amass/v3/...@latest
+    install_command: go install -v github.com/owasp-amass/amass/v3/...@latest
     version_match_regex: v(\d+\.)?(\d+\.)?(\*|\d+)
     is_default: true
     is_subdomain_gathering: true


### PR DESCRIPTION
The newer version for Amass has a different go directory defined for installation and update. This is causing build failure of Rengine after the recent changes.