### PR TITLE
Hotfix: revert commit that broke scanning

### DIFF
--- a/web/api/serializers.py
+++ b/web/api/serializers.py
@@ -429,15 +429,15 @@ class VisualiseSubdomainSerializer(serializers.ModelSerializer):
 					'description': 'Informational',
 					'children': info_serializer.data
 				})
-			unknown = vulnerability.filter(severity=-1)
-			if unknown:
-				unknown_serializer = VisualiseVulnerabilitySerializer(
-					unknown,
+			uknown = vulnerability.filter(severity=-1)
+			if uknown:
+				uknown_serializer = VisualiseVulnerabilitySerializer(
+					uknown,
 					many=True
 				)
 				vulnerability_data.append({
 					'description': 'Unknown',
-					'children': unknown_serializer.data
+					'children': uknown_serializer.data
 				})
 
 			if vulnerability_data:


### PR DESCRIPTION
@yogeshojha

I don't know why though. I went through the code, even searched for `uknown` but I guess it's being renamed somewhere else in the code, but then that'd have been picked up by my search too. So for some reason, something depends on `uknown`. Do you have any idea?

I confirmed by testing that this commit fixes the scanning.

ref: https://github.com/yogeshojha/rengine/commit/fd61c6b315b5aa15ac883940bc59e216829e069c