### PR TITLE
ops(`uninstall.sh`): fix incorrect container names

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cat ../web/art/rengine.txt
+cat ../web/art/reNgine.txt
 echo "Uninstalling reNgine"
 
 if [ "$EUID" -ne 0 ]
@@ -11,10 +11,10 @@ if [ "$EUID" -ne 0 ]
 fi
 
 echo "Stopping reNgine"
-docker stop rengine_web_1 rengine_db_1 rengine_celery_1 rengine_celery-beat_1 rengine_redis_1 rengine_tor_1 rengine_proxy_1
+docker stop rengine-web-1 rengine-db-1 rengine-celery-1 rengine-celery-beat-1 rengine-redis-1 rengine-tor-1 rengine-proxy-1
 
 echo "Removing all Containers related to reNgine"
-docker rm rengine_web_1 rengine_db_1 rengine_celery_1 rengine_celery-beat_1 rengine_redis_1 rengine_tor_1 rengine_proxy_1
+docker rm rengine-web-1 rengine-db-1 rengine-celery-1 rengine-celery-beat-1 rengine-redis-1 rengine-tor-1 rengine-proxy-1
 echo "Removed all Containers"
 
 echo "Removing All volumes related to reNgine"
@@ -22,6 +22,6 @@ docker volume rm rengine_gf_patterns rengine_github_repos rengine_nuclei_templat
 echo "Removed all Volumes"
 
 echo "Removing all networks related to reNgine"
-docker network rm rengine_rengine_network
+docker network rm rengine_rengine_network rengine_default
 
 echo "Finished Uninstalling."

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -13,15 +13,15 @@ fi
 echo "Stopping reNgine"
 docker stop rengine-web-1 rengine-db-1 rengine-celery-1 rengine-celery-beat-1 rengine-redis-1 rengine-tor-1 rengine-proxy-1
 
-echo "Removing all Containers related to reNgine"
+echo "Removing all containers related to reNgine"
 docker rm rengine-web-1 rengine-db-1 rengine-celery-1 rengine-celery-beat-1 rengine-redis-1 rengine-tor-1 rengine-proxy-1
-echo "Removed all Containers"
+echo "Removed all containers"
 
-echo "Removing All volumes related to reNgine"
+echo "Removing all volumes related to reNgine"
 docker volume rm rengine_gf_patterns rengine_github_repos rengine_nuclei_templates rengine_postgres_data rengine_scan_results rengine_tool_config
-echo "Removed all Volumes"
+echo "Removed all volumes"
 
 echo "Removing all networks related to reNgine"
 docker network rm rengine_rengine_network rengine_default
 
-echo "Finished Uninstalling."
+echo "Finished uninstalling."

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -18,7 +18,7 @@ docker rm rengine-web-1 rengine-db-1 rengine-celery-1 rengine-celery-beat-1 reng
 echo "Removed all containers"
 
 echo "Removing all volumes related to reNgine"
-docker volume rm rengine_gf_patterns rengine_github_repos rengine_nuclei_templates rengine_postgres_data rengine_scan_results rengine_tool_config
+docker volume rm rengine_gf_patterns rengine_github_repos rengine_nuclei_templates rengine_postgres_data rengine_scan_results rengine_tool_config rengine_static_volume rengine_wordlist
 echo "Removed all volumes"
 
 echo "Removing all networks related to reNgine"


### PR DESCRIPTION
# Fixes

- **Incorrect container names:** the incorrect container names caused that the containers, volumes and networks weren't being removed as it requires the containers to be stopped
- **reNgine art not showing:** this was caused by the incorrect filename (`rengine.txt` instead of `reNgine.txt`)

**Before:**

![image](https://user-images.githubusercontent.com/50231698/232302674-0b8f0b0a-ce32-43c2-b056-ba2b3a94c95e.png)

**After:**

![image](https://user-images.githubusercontent.com/50231698/232302804-d285fce3-2c7c-4bc3-a364-3cc1ce38cc06.png)
