### PR TITLE
chore(`.gitignore`): add environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ secret
 /secrets
 
 get-docker.sh
+
+# Environment variables
+.env


### PR DESCRIPTION
Bad security practice in case someone accidentally commits its environment variable, potentially exposing the URL, username and password. Example: https://github.com/yogeshojha/rengine/pull/742/files#r1171128911.