### PR TITLE
Proxy bug fix with ffuf

### DIFF
--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -1329,19 +1329,19 @@ def directory_fuzz(
 		else:
 			http_url = subdomain
 
-		# proxy
-		proxy = get_random_proxy()
-		if proxy:
-			ffuf_command = '{} -x {} '.format(
-				ffuf_command,
-				proxy
-			)
-
-		command = '{} -u {} -o {} -of json'.format(
+		command = '{} -u {} -o {} -of json '.format(
 			ffuf_command,
 			http_url,
 			dirs_results
 		)
+
+		# proxy
+		proxy = get_random_proxy()
+		if proxy:
+			command = '{} -x {} '.format(
+				command,
+				proxy
+			)
 
 		logger.info(command)
 		process = subprocess.Popen(command.split())


### PR DESCRIPTION
Encountered a bug with ffuf when I configured a proxy on reNgine. The proxy would get added again for each subdomains, this led to this:

![image](https://github.com/yogeshojha/rengine/assets/17783445/21feaa39-489e-4fea-8a31-4b020e108452)

This is due to the fact that the proxy was added to the variable ffuf_command again and again rather that one time everytime a random proxy was retrieved. This pull request aims to fix this bug.
