### PR TITLE
Resolve popen split

### DIFF
--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import random
+import shlex
 import subprocess
 import time
 import traceback
@@ -544,7 +545,7 @@ def subdomain_scan(
 						amass_command += ' -config /root/.config/amass.ini'
 					# Run Amass Passive
 					logging.info(amass_command)
-					process = subprocess.Popen(amass_command.split())
+					process = subprocess.Popen(shlex.split(amass_command))
 					process.wait()
 
 				elif tool == 'amass-active':
@@ -567,7 +568,7 @@ def subdomain_scan(
 
 					# Run Amass Active
 					logging.info(amass_command)
-					process = subprocess.Popen(amass_command.split())
+					process = subprocess.Popen(shlex.split(amass_command))
 					process.wait()
 
 				elif tool == 'assetfinder':
@@ -576,7 +577,7 @@ def subdomain_scan(
 
 					# Run Assetfinder
 					logging.info(assetfinder_command)
-					process = subprocess.Popen(assetfinder_command.split())
+					process = subprocess.Popen(shlex.split(assetfinder_command))
 					process.wait()
 
 				elif tool == 'sublist3r':
@@ -585,7 +586,7 @@ def subdomain_scan(
 
 					# Run sublist3r
 					logging.info(sublist3r_command)
-					process = subprocess.Popen(sublist3r_command.split())
+					process = subprocess.Popen(shlex.split(sublist3r_command))
 					process.wait()
 
 				elif tool == 'subfinder':
@@ -597,7 +598,7 @@ def subdomain_scan(
 
 					# Run Subfinder
 					logging.info(subfinder_command)
-					process = subprocess.Popen(subfinder_command.split())
+					process = subprocess.Popen(shlex.split(subfinder_command))
 					process.wait()
 
 				elif tool == 'oneforall':
@@ -606,7 +607,7 @@ def subdomain_scan(
 
 					# Run OneForAll
 					logging.info(oneforall_command)
-					process = subprocess.Popen(oneforall_command.split())
+					process = subprocess.Popen(shlex.split(oneforall_command))
 					process.wait()
 
 					extract_subdomain = "cut -d',' -f6 /usr/src/github/OneForAll/results/{}.csv >> {}/from_oneforall.txt".format(
@@ -630,7 +631,7 @@ def subdomain_scan(
 						execution_command = execution_command.replace('{OUTPUT}', '{}/from_{}.txt'.format(results_dir, tool))
 						execution_command = execution_command.replace('{PATH}', custom_tool.github_clone_path) if '{PATH}' in execution_command else execution_command
 						logger.info('Custom tool {} running with command {}'.format(tool, execution_command))
-						process = subprocess.Popen(execution_command.split())
+						process = subprocess.Popen(shlex.split(execution_command))
 						process.wait()
 					else:
 						logger.error('Sorry can not run this tool! because TARGET and OUTPUT are not available!')
@@ -940,7 +941,7 @@ def grab_screenshot(task, domain, yaml_configuration, results_dir, activity_id):
 
 	logger.info(eyewitness_command)
 
-	process = subprocess.Popen(eyewitness_command.split())
+	process = subprocess.Popen(shlex.split(eyewitness_command))
 	process.wait()
 
 	if os.path.isfile(result_csv_path):
@@ -1048,7 +1049,7 @@ def port_scanning(
 
 	# run naabu
 	logger.info(naabu_command)
-	process = subprocess.Popen(naabu_command.split())
+	process = subprocess.Popen(shlex.split(naabu_command))
 	process.wait()
 
 	# writing port results
@@ -1132,7 +1133,7 @@ def check_waf(scan_history, results_dir):
 
 		logger.info(wafw00f_command)
 
-		process = subprocess.Popen(wafw00f_command.split())
+		process = subprocess.Popen(shlex.split(wafw00f_command))
 		process.wait()
 
 		# check if wafw00f has generated output file
@@ -1332,7 +1333,7 @@ def directory_fuzz(
 		)
 
 		logger.info(command)
-		process = subprocess.Popen(command.split())
+		process = subprocess.Popen(shlex.split(command))
 		process.wait()
 
 		try:
@@ -1871,7 +1872,7 @@ def vulnerability_scan(
 
 		logger.info('Running Nuclei Scanner!')
 		logger.info(final_nuclei_command)
-		process = subprocess.Popen(final_nuclei_command.split())
+		process = subprocess.Popen(shlex.split(final_nuclei_command))
 		process.wait()
 
 		try:

--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -1845,7 +1845,7 @@ def vulnerability_scan(
 		nuclei_command = nuclei_command + ' -retries ' + str(retries)
 
 	if CUSTOM_HEADER in yaml_configuration and yaml_configuration[CUSTOM_HEADER]:
-		nuclei_command += ' -H "{}" '.format(yaml_configuration[CUSTOM_HEADER])
+		nuclei_command += ' -H "{}"'.format(yaml_configuration[CUSTOM_HEADER])
 
 	# for severity and new severity in nuclei
 	if NUCLEI_SEVERITY in yaml_configuration[VULNERABILITY_SCAN] and ALL not in yaml_configuration[VULNERABILITY_SCAN][NUCLEI_SEVERITY]:

--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -1,50 +1,38 @@
-import os
-import traceback
-import yaml
-import json
 import csv
-import validators
-import random
-import requests
-import time
+import json
 import logging
-import metafinder.extractor as metadata_extractor
-import whatportis
+import os
+import random
 import subprocess
-
+import time
+import traceback
+from datetime import datetime
 from random import randint
 from time import sleep
-from selenium.webdriver.firefox.options import Options as FirefoxOptions
-from selenium import webdriver
-from emailfinder.extractor import *
-from dotted_dict import DottedDict
-from celery import shared_task
-from discord_webhook import DiscordWebhook
-from reNgine.celery import app
-from startScan.models import *
-from targetApp.models import Domain
-from scanEngine.models import EngineType
-from django.conf import settings
-from django.shortcuts import get_object_or_404
 
+import metafinder.extractor as metadata_extractor
+import requests
+import validators
+import whatportis
+import yaml
 from celery import shared_task
-from datetime import datetime
 from degoogle import degoogle
-
+from discord_webhook import DiscordWebhook
 from django.conf import settings
-from django.utils import timezone, dateformat
-from django.shortcuts import get_object_or_404
 from django.core.exceptions import ObjectDoesNotExist
-
+from django.shortcuts import get_object_or_404
+from django.utils import dateformat, timezone
+from dotted_dict import DottedDict
+from emailfinder.extractor import *
 from reNgine.celery import app
 from reNgine.definitions import *
-
+from scanEngine.models import Configuration, EngineType, Wordlist
+from selenium import webdriver
+from selenium.webdriver.firefox.options import Options as FirefoxOptions
 from startScan.models import *
 from targetApp.models import Domain
-from scanEngine.models import EngineType, Configuration, Wordlist
 
 from .common_func import *
-
 
 '''
 	All the background tasks to be executed in celery will be here


### PR DESCRIPTION
When defining the severity of a vulnerability_scan the nuclei command whas always running a scan on all severities.
The problem was due to the `subprocess.Popen(command.split())` call.
Split is not the proper way to split strings for subprocess commands:
```python3
>>> a='nuclei -j -l targets.txt -o vulnerability.json -c 10 -rl 150 -timeout 5 -retries 1 -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:113.0) Gecko/20100101 Firefox/113.0" -severity critical'
>>> a.split()
['nuclei', '-j', '-l', 'targets.txt', '-o', 'vulnerability.json', '-c', '10', '-rl', '150', '-timeout', '5', '-retries', '1', '-H', '"User-Agent:', 'Mozilla/5.0', '(Windows', 'NT', '10.0;', 'rv:113.0)', 'Gecko/20100101', 'Firefox/113.0"', '-severity', 'critical']
```
Shlex is the recommanded way to split commands for Popen:
```python3
>>> import shlex
>>> shlex.split(a)
['nuclei', '-j', '-l', 'targets.txt', '-o', 'vulnerability.json', '-c', '10', '-rl', '150', '-timeout', '5', '-retries', '1', '-H', 'User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:113.0) Gecko/20100101 Firefox/113.0', '-severity', 'critical']
```