### PR TITLE
fix(port-scan): `int` object is not subscriptable

### DIFF
--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -1069,7 +1069,7 @@ def port_scanning(
 		lines = port_json_result.readlines()
 		for line in lines:
 			json_st = json.loads(line.strip())
-			port_number = json_st['port']['Port']
+			port_number = json_st['port']
 			ip_address = json_st['ip']
 			host = json_st['host']
 


### PR DESCRIPTION
Fixes #939, fixes #938