### PR TITLE
ops(`install.sh`): fix reNgine not installing using WSL

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -92,12 +92,9 @@ tput setaf 4;
 echo "#########################################################################"
 echo "Checking Docker status"
 echo "#########################################################################"
-if systemctl is-active docker >/dev/null 2>&1; then
+if docker info >/dev/null 2>&1; then
   tput setaf 4;
   echo "Docker is running."
- elif service docker status > /dev/null 2>&1; then
-  tput setaf 4;
-  echo "Docker is running"
 else
   tput setaf 1;
   echo "Docker is not running. Please run docker and try again."


### PR DESCRIPTION
Because the previous implementation was way too specific, it resulted in reNgine not installing on WSL environments in combination with Docker Desktop. That's why [even Docker recommends](https://docs.docker.com/config/daemon/troubleshoot/#check-whether-docker-is-running) executing the `docker info` command instead to see whether Docker is working and running.

Fixes #956.