### PR TITLE
Add stack trace into make logs if DEBUG True

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,52 @@ You can also [join our Discord channel #development](https://discord.gg/JuhHdHTt
 
 ![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/aqua.png)
 
+### Submitting issues
+
+You can submit issue to the project but you should do it in a way that helps developers to resolve it as quickly as possible.
+
+For that, you need to add as much valuable informations as possible.
+
+You can have this valuable informations by doing this steps :
+
+- Go to the root of the git cloned project
+- Edit `web/entrypoint.sh` and add at the top `export DEBUG=1`
+This should give you this result
+  ```python
+  #!/bin/bash
+
+  export DEBUG=1
+
+  python3 manage.py migrate
+  python3 manage.py runserver 0.0.0.0:8000
+
+  exec "$@"
+  ```
+- Restart the web container `docker-compose restart web`
+- To deactivate set **DEBUG** to **0** and restart web container again
+
+Then, with **DEBUG** set to **1**, in the `make logs` output you could see the full stack trace to debug reNgine.
+
+Example with the tool arsenal version check API bug.
+```
+web_1          |   File "/usr/local/lib/python3.10/dist-packages/celery/app/task.py", line 411, in __call__
+web_1          |     return self.run(*args, **kwargs)
+web_1          | TypeError: run_command() got an unexpected keyword argument 'echo'
+```
+Now you know the real error is `TypeError: run_command() got an unexpected keyword argument 'echo'`
+
+And you can post the full stack trace to your newly created issue to help developers to track the root cause of the bug and correct the bug easily
+
+__Activating debug like this also give you the full stack trace in the browser__ instead of a 500 Error without any details.
+So don't forget to open the developer console and check for any XHR request with 500 error.
+If there's any check the response of this request to get your detailed error.
+
+<img src="https://user-images.githubusercontent.com/1230954/276260955-ed1e1168-7c8f-43a3-b54d-b6285d52b771.png">
+
+Happy issuing ;)
+
+![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/aqua.png)
+
 ### First-time Open Source contributors
 
 Please note that reNgine is beginner friendly. If you have never done open-source before, we encourage you to do so. **We will be happy and proud of your first PR ever.**

--- a/README.md
+++ b/README.md
@@ -416,13 +416,14 @@ You can also [join our Discord channel #development](https://discord.gg/JuhHdHTt
 
 You can submit issues related to this project, but you should do it in a way that helps developers to resolve it as quickly as possible.
 
-For that, you need to add as much valuable informations as possible.
+For that, you need to add as much valuable information as possible.
 
-You can have this valuable informations by doing this steps :
+You can have this valuable information by following these steps:
 
 - Go to the root of the git cloned project
-- Edit `web/entrypoint.sh` and add at the top `export DEBUG=1`
+- Edit `web/entrypoint.sh` and add `export DEBUG=1` at the top
 This should give you this result
+
   ```python
   #!/bin/bash
 
@@ -433,12 +434,13 @@ This should give you this result
 
   exec "$@"
   ```
-- Restart the web container `docker-compose restart web`
-- To deactivate set **DEBUG** to **0** and restart web container again
+- Restart the web container: `docker-compose restart web`
+- To deactivate, set **DEBUG** to **0** and restart the web container again
 
 Then, with **DEBUG** set to **1**, in the `make logs` output you could see the full stack trace to debug reNgine.
 
 Example with the tool arsenal version check API bug.
+
 ```
 web_1          |   File "/usr/local/lib/python3.10/dist-packages/celery/app/task.py", line 411, in __call__
 web_1          |     return self.run(*args, **kwargs)
@@ -448,9 +450,9 @@ Now you know the real error is `TypeError: run_command() got an unexpected keywo
 
 And you can post the full stack trace to your newly created issue to help developers to track the root cause of the bug and correct the bug easily
 
-__Activating debug like this also give you the full stack trace in the browser__ instead of a 500 Error without any details.
-So don't forget to open the developer console and check for any XHR request with 500 error.
-If there's any check the response of this request to get your detailed error.
+**Activating debug like this also give you the full stack trace in the browser** instead of an error 500 without any details.
+So don't forget to open the developer console and check for any XHR request with error 500.
+If there's any, check the response of this request to get your detailed error.
 
 <img src="https://user-images.githubusercontent.com/1230954/276260955-ed1e1168-7c8f-43a3-b54d-b6285d52b771.png">
 

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ You can also [join our Discord channel #development](https://discord.gg/JuhHdHTt
 
 ### Submitting issues
 
-You can submit issue to the project but you should do it in a way that helps developers to resolve it as quickly as possible.
+You can submit issues related to this project, but you should do it in a way that helps developers to resolve it as quickly as possible.
 
 For that, you need to add as much valuable informations as possible.
 

--- a/web/celery-entrypoint.sh
+++ b/web/celery-entrypoint.sh
@@ -148,7 +148,7 @@ exec "$@"
 # httpx seems to have issue, use alias instead!!!
 echo 'alias httpx="/go/bin/httpx"' >> ~/.bashrc
 
-loglevel='$loglevel'
+loglevel='info'
 if [ "$DEBUG" == "1" ]; then
     loglevel='debug'
 fi

--- a/web/celery-entrypoint.sh
+++ b/web/celery-entrypoint.sh
@@ -148,29 +148,33 @@ exec "$@"
 # httpx seems to have issue, use alias instead!!!
 echo 'alias httpx="/go/bin/httpx"' >> ~/.bashrc
 
+loglevel='$loglevel'
+if [ "$DEBUG" == "1" ]; then
+    loglevel='debug'
+fi
 
 # watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --autoscale=10,0 -l INFO -Q scan_queue &
 echo "Starting Workers..."
 echo "Starting Main Scan Worker with Concurrency: $MAX_CONCURRENCY,$MIN_CONCURRENCY"
-watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --loglevel=info --autoscale=$MAX_CONCURRENCY,$MIN_CONCURRENCY -Q main_scan_queue &
-watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=30 --loglevel=info -Q initiate_scan_queue -n initiate_scan_worker &
-watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=30 --loglevel=info -Q subscan_queue -n subscan_worker &
-watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=20 --loglevel=info -Q report_queue -n report_worker &
-watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=10 --loglevel=info -Q send_notif_queue -n send_notif_worker &
-watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=10 --loglevel=info -Q send_scan_notif_queue -n send_scan_notif_worker &
-watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=10 --loglevel=info -Q send_task_notif_queue -n send_task_notif_worker &
-watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=5 --loglevel=info -Q send_file_to_discord_queue -n send_file_to_discord_worker &
-watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=5 --loglevel=info -Q send_hackerone_report_queue -n send_hackerone_report_worker &
-watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=10 --loglevel=info -Q parse_nmap_results_queue -n parse_nmap_results_worker &
-watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=20 --loglevel=info -Q geo_localize_queue -n geo_localize_worker &
-watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=10 --loglevel=info -Q query_whois_queue -n query_whois_worker &
-watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=30 --loglevel=info -Q remove_duplicate_endpoints_queue -n remove_duplicate_endpoints_worker &
-watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=50 --loglevel=info -Q run_command_queue -n run_command_worker &
-watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=10 --loglevel=info -Q query_reverse_whois_queue -n query_reverse_whois_worker &
-watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=10 --loglevel=info -Q query_ip_history_queue -n query_ip_history_worker &
-watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=30 --loglevel=info -Q gpt_queue -n gpt_worker &
-watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=10 --loglevel=info -Q dorking_queue -n dorking_worker &
-watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=10 --loglevel=info -Q osint_discovery_queue -n osint_discovery_worker &
-watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=10 --loglevel=info -Q h8mail_queue -n h8mail_worker &
-watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=10 --loglevel=info -Q theHarvester_queue -n theHarvester_worker
+watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --loglevel=$loglevel --autoscale=$MAX_CONCURRENCY,$MIN_CONCURRENCY -Q main_scan_queue &
+watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=30 --loglevel=$loglevel -Q initiate_scan_queue -n initiate_scan_worker &
+watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=30 --loglevel=$loglevel -Q subscan_queue -n subscan_worker &
+watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=20 --loglevel=$loglevel -Q report_queue -n report_worker &
+watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=10 --loglevel=$loglevel -Q send_notif_queue -n send_notif_worker &
+watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=10 --loglevel=$loglevel -Q send_scan_notif_queue -n send_scan_notif_worker &
+watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=10 --loglevel=$loglevel -Q send_task_notif_queue -n send_task_notif_worker &
+watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=5 --loglevel=$loglevel -Q send_file_to_discord_queue -n send_file_to_discord_worker &
+watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=5 --loglevel=$loglevel -Q send_hackerone_report_queue -n send_hackerone_report_worker &
+watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=10 --loglevel=$loglevel -Q parse_nmap_results_queue -n parse_nmap_results_worker &
+watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=20 --loglevel=$loglevel -Q geo_localize_queue -n geo_localize_worker &
+watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=10 --loglevel=$loglevel -Q query_whois_queue -n query_whois_worker &
+watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=30 --loglevel=$loglevel -Q remove_duplicate_endpoints_queue -n remove_duplicate_endpoints_worker &
+watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=50 --loglevel=$loglevel -Q run_command_queue -n run_command_worker &
+watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=10 --loglevel=$loglevel -Q query_reverse_whois_queue -n query_reverse_whois_worker &
+watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=10 --loglevel=$loglevel -Q query_ip_history_queue -n query_ip_history_worker &
+watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=30 --loglevel=$loglevel -Q gpt_queue -n gpt_worker &
+watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=10 --loglevel=$loglevel -Q dorking_queue -n dorking_worker &
+watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=10 --loglevel=$loglevel -Q osint_discovery_queue -n osint_discovery_worker &
+watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=10 --loglevel=$loglevel -Q h8mail_queue -n h8mail_worker &
+watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --pool=gevent --concurrency=10 --loglevel=$loglevel -Q theHarvester_queue -n theHarvester_worker
 exec "$@"

--- a/web/reNgine/settings.py
+++ b/web/reNgine/settings.py
@@ -231,7 +231,13 @@ LOGGING = {
             'filename': 'db.log',
             'maxBytes': 1024,
             'backupCount': 3
-        }
+        },
+        'celery': {
+            'class': 'logging.handlers.RotatingFileHandler',
+            'formatter': 'simple',
+            'filename': 'celery.log',
+            'maxBytes': 1024 * 1024 * 100,  # 100 mb
+        },
     },
     'formatters': {
         'default': {
@@ -242,6 +248,10 @@ LOGGING = {
         },
         'task': {
             '()': lambda : RengineTaskFormatter('%(task_name)-34s | %(levelname)s | %(message)s')
+        },
+        'simple': {
+            'format': '%(levelname)s %(message)s',
+            'datefmt': '%y %b %d, %H:%M:%S',
         }
     },
     'loggers': {
@@ -254,6 +264,10 @@ LOGGING = {
             'handlers': ['brief'],
             'level': 'DEBUG' if DEBUG else 'INFO',
             'propagate': False
+        },
+        'celery': {
+            'handlers': ['celery'],
+            'level': 'DEBUG' if DEBUG else 'ERROR',
         },
         'celery.app.trace': {
             'handlers': ['null'],

--- a/web/reNgine/settings.py
+++ b/web/reNgine/settings.py
@@ -201,6 +201,11 @@ LOGGING = {
     'version': 1,
     'disable_existing_loggers': True,
     'handlers': {
+        'file': {
+            'level': 'ERROR',
+            'class': 'logging.FileHandler',
+            'filename': 'errors.log',
+        },
         'null': {
             'class': 'logging.NullHandler'
         },
@@ -240,6 +245,11 @@ LOGGING = {
         }
     },
     'loggers': {
+        'django': {
+            'handlers': ['file'],
+            'level': 'ERROR' if DEBUG else 'CRITICAL',
+            'propagate': True,
+        },
         '': {
             'handlers': ['brief'],
             'level': 'DEBUG' if DEBUG else 'INFO',


### PR DESCRIPTION
To track Error 500 and easily debug reNgine from the `make logs` command

To activate debug, from the root directory of reNgine :

1. Edit `web/entrypoint.sh` and add at the top `export DEBUG=1`
```sh
#!/bin/bash

export DEBUG=1

python3 manage.py migrate
python3 manage.py runserver 0.0.0.0:8000

exec "$@"
```
2. Restart the web container `docker-compose restart web`
3. To deactivate set **DEBUG** to **0** and restart  web container

Then, with **DEBUG** set to **1**, in the `make logs` output you could see the full stack trace to debug reNgine,.
Example with the tool arsenal version check API bug.
Now you know the real error `TypeError: run_command() got an unexpected keyword argument 'echo'`
And you can post it to the issue you can create to help developers to track the root cause and correct the bug easily
```
proxy_1        | 172.16.20.6 - - [18/Oct/2023:12:32:59 +0000] "GET /api/external/tool/get_current_release/?tool_id=12 HTTP/2.0" 500 103547 "https://rengine.local/scanEngine/cw-okay/tool_arsenal" "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/118.0" "-"
web_1          | django.request | Internal Server Error: /api/external/tool/get_current_release/
web_1          | Traceback (most recent call last):
web_1          |   File "/usr/local/lib/python3.10/dist-packages/django/core/handlers/exception.py", line 47, in inner
web_1          |     response = get_response(request)
web_1          |   File "/usr/local/lib/python3.10/dist-packages/django/core/handlers/base.py", line 181, in _get_response
web_1          |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
web_1          |   File "/usr/local/lib/python3.10/dist-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
web_1          |     return view_func(*args, **kwargs)
web_1          |   File "/usr/local/lib/python3.10/dist-packages/django/views/generic/base.py", line 70, in view
web_1          |     return self.dispatch(request, *args, **kwargs)
web_1          |   File "/usr/local/lib/python3.10/dist-packages/rest_framework/views.py", line 509, in dispatch
web_1          |     response = self.handle_exception(exc)
web_1          |   File "/usr/local/lib/python3.10/dist-packages/rest_framework/views.py", line 469, in handle_exception
web_1          |     self.raise_uncaught_exception(exc)
web_1          |   File "/usr/local/lib/python3.10/dist-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
web_1          |     raise exc
web_1          |   File "/usr/local/lib/python3.10/dist-packages/rest_framework/views.py", line 506, in dispatch
web_1          |     response = handler(request, *args, **kwargs)
web_1          |   File "/usr/src/app/api/views.py", line 922, in get
web_1          |     _, stdout = run_command(tool.version_lookup_command, echo=True)
web_1          |   File "/usr/local/lib/python3.10/dist-packages/celery/local.py", line 182, in __call__
web_1          |     return self._get_current_object()(*a, **kw)
web_1          |   File "/usr/local/lib/python3.10/dist-packages/celery/app/task.py", line 411, in __call__
web_1          |     return self.run(*args, **kwargs)
web_1          | TypeError: run_command() got an unexpected keyword argument 'echo'
```

Activating debug like this also give you the full stack trace in the browser
Here the schedule scan 500 error
![image](https://github.com/yogeshojha/rengine/assets/1230954/ed1e1168-7c8f-43a3-b54d-b6285d52b771)


