### PR TITLE
Gau install

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -77,7 +77,7 @@ RUN go install -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest
 RUN go install -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei@latest
 RUN go install -v github.com/projectdiscovery/naabu/v2/cmd/naabu@latest
 RUN go install -v github.com/hakluke/hakrawler@latest
-RUN go install -v -v github.com/bp0lr/gauplus@latest
+RUN go install -v github.com/lc/gau/v2/cmd/gau@latest
 RUN go install -v github.com/jaeles-project/gospider@latest
 RUN go install -v github.com/owasp-amass/amass/v3/...@latest
 RUN go install -v github.com/ffuf/ffuf@latest

--- a/web/fixtures/default_scan_engines.yaml
+++ b/web/fixtures/default_scan_engines.yaml
@@ -21,12 +21,12 @@
       \ 'follow_redirect': false,\r\n  'max_time': 0,\r\n  'match_http_status': [200,
       204],\r\n  'recursive_level': 2,\r\n  'stop_on_error': false,\r\n  'timeout':
       5,\r\n  'threads': 30,\r\n  'wordlist_name': 'dicc'\r\n}\r\nfetch_url: {\r\n
-      \ 'uses_tools': ['gospider', 'hakrawler', 'waybackurls', 'gospider', 'katana'],\r\n
+      \ 'uses_tools': ['gospider', 'hakrawler', 'waybackurls', 'gospider', 'katana', 'gau'],\r\n
       \ 'remove_duplicate_endpoints': true,\r\n  'duplicate_fields': ['content_length',
       'page_title'],\r\n  'enable_http_crawl': true,\r\n  'gf_patterns': ['debug_logic',
       'idor', 'interestingEXT', 'interestingparams', 'interestingsubs', 'lfi', 'rce',
       'redirect', 'sqli', 'ssrf', 'ssti', 'xss'],\r\n  'ignore_file_extensions': ['png',
-      'jpg', 'jpeg', 'gif', 'mp4', 'mpeg', 'mp3']\r\n}\r\nvulnerability_scan: {\r\n
+      'jpg', 'jpeg', 'gif', 'mp4', 'mpeg', 'mp3'],\r\n  'threads': 30\r\n}\r\nvulnerability_scan: {\r\n
       \ 'run_nuclei': true,\r\n  'run_dalfox': true,\r\n  'run_crlfuzz': true,\r\n
       \ 'enable_http_crawl': true,\r\n  'concurrency': 50,\r\n  'intensity': 'normal',\r\n
       \ 'rate_limit': 150,\r\n  'retries': 1,\r\n  'timeout': 5,\r\n  'fetch_gpt_report':

--- a/web/fixtures/external_tools.yaml
+++ b/web/fixtures/external_tools.yaml
@@ -329,3 +329,20 @@
     is_github_cloned: false
     github_clone_path: null
     subdomain_gathering_command: null
+- model: scanEngine.installedexternaltool
+  pk: 19
+  fields:
+    logo_url: null
+    name: gau
+    description: Get all URLs
+    github_url: https://github.com/lc/gau
+    license_url: https://github.com/lc/gau/blob/main/LICENSE
+    version_lookup_command: gau --version
+    update_command: go install github.com/lc/gau/v2/cmd/gau@latest
+    install_command: go install github.com/lc/gau/v2/cmd/gau@latest
+    version_match_regex: '[vV]*(\d+\.)?(\d+\.)?(\*|\d+)'
+    is_default: true
+    is_subdomain_gathering: false
+    is_github_cloned: false
+    github_clone_path: null
+    subdomain_gathering_command: null

--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -1707,7 +1707,7 @@ def dir_file_fuzz(self, ctx={}, description=None):
 
 @app.task(name='fetch_url', queue='main_scan_queue', base=RengineTask, bind=True)
 def fetch_url(self, urls=[], ctx={}, description=None):
-	"""Fetch URLs using different tools like gauplus, gospider, waybackurls ...
+	"""Fetch URLs using different tools like gauplus, gau, gospider, waybackurls ...
 
 	Args:
 		urls (list): List of URLs to start from.
@@ -1748,18 +1748,21 @@ def fetch_url(self, urls=[], ctx={}, description=None):
 
 	# Tools cmds
 	cmd_map = {
-		'gauplus': f'gauplus --random-agent -t {threads}',
+		'gau': f'gau',
+		'gauplus': f'gauplus -random-agent',
 		'hakrawler': 'hakrawler -subs -u',
 		'waybackurls': 'waybackurls',
 		'gospider': f'gospider -S {input_path} --js -d 2 --sitemap --robots -w -r',
 		'katana': f'katana -list {input_path} -silent -jc -kf all -d 3 -fs rdn',
 	}
 	if proxy:
+		cmd_map['gau'] += f' --proxy "{proxy}"'
 		cmd_map['gauplus'] += f' -p "{proxy}"'
 		cmd_map['gospider'] += f' -p {proxy}'
 		cmd_map['hakrawler'] += f' -proxy {proxy}'
 		cmd_map['katana'] += f' -proxy {proxy}'
 	if threads > 0:
+		cmd_map['gau'] += f' --threads {threads}'
 		cmd_map['gauplus'] += f' -t {threads}'
 		cmd_map['gospider'] += f' -t {threads}'
 		cmd_map['katana'] += f' -c {threads}'

--- a/web/scanEngine/templates/scanEngine/add_engine.html
+++ b/web/scanEngine/templates/scanEngine/add_engine.html
@@ -141,7 +141,8 @@ fetch_url: {
     'hakrawler',
     'waybackurls',
     'gospider',
-    'katana'
+    'katana',
+    'gau'
   ],
   'remove_duplicate_endpoints': true,
   'duplicate_fields': [
@@ -150,7 +151,8 @@ fetch_url: {
   ],
   'enable_http_crawl': true,
   'gf_patterns': ['debug_logic', 'idor', 'interestingEXT', 'interestingparams', 'interestingsubs', 'lfi', 'rce', 'redirect', 'sqli', 'ssrf', 'ssti', 'xss'],
-  'ignore_file_extensions': ['png', 'jpg', 'jpeg', 'gif', 'mp4', 'mpeg', 'mp3']
+  'ignore_file_extensions': ['png', 'jpg', 'jpeg', 'gif', 'mp4', 'mpeg', 'mp3'],
+  'threads': 30
   # 'exclude_subdomains': true
 }
 vulnerability_scan: {


### PR DESCRIPTION
Fix #997 

Add gau in renGine
![image](https://github.com/yogeshojha/rengine/assets/1230954/db3a64c1-4ea4-4abf-912f-8bae12b68085)

Gauplus is always there but not in the default config.

Need a `make down && make up`

Fully tested & working