### PR TITLE
Fix nmap script ports iterable args

### DIFF
--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -1708,7 +1708,7 @@ def dir_file_fuzz(self, ctx={}, description=None):
 
 @app.task(name='fetch_url', queue='main_scan_queue', base=RengineTask, bind=True)
 def fetch_url(self, urls=[], ctx={}, description=None):
-	"""Fetch URLs using different tools like gauplus, gau, gospider, waybackurls ...
+	"""Fetch URLs using different tools like gauplus, gospider, waybackurls ...
 
 	Args:
 		urls (list): List of URLs to start from.
@@ -1749,21 +1749,18 @@ def fetch_url(self, urls=[], ctx={}, description=None):
 
 	# Tools cmds
 	cmd_map = {
-		'gau': f'gau',
-		'gauplus': f'gauplus -random-agent',
+		'gauplus': f'gauplus --random-agent -t {threads}',
 		'hakrawler': 'hakrawler -subs -u',
 		'waybackurls': 'waybackurls',
 		'gospider': f'gospider -S {input_path} --js -d 2 --sitemap --robots -w -r',
 		'katana': f'katana -list {input_path} -silent -jc -kf all -d 3 -fs rdn',
 	}
 	if proxy:
-		cmd_map['gau'] += f' --proxy "{proxy}"'
 		cmd_map['gauplus'] += f' -p "{proxy}"'
 		cmd_map['gospider'] += f' -p {proxy}'
 		cmd_map['hakrawler'] += f' -proxy {proxy}'
 		cmd_map['katana'] += f' -proxy {proxy}'
 	if threads > 0:
-		cmd_map['gau'] += f' --threads {threads}'
 		cmd_map['gauplus'] += f' -t {threads}'
 		cmd_map['gospider'] += f' -t {threads}'
 		cmd_map['katana'] += f' -c {threads}'

--- a/web/reNgine/utilities.py
+++ b/web/reNgine/utilities.py
@@ -37,6 +37,13 @@ def get_time_taken(latest, earlier):
 		return '{} hours'.format(hours)
 	return '{} hours {} minutes'.format(hours, minutes)
 
+# Check if value is a simple string, a string with commas, a list [], a tuple (), a set {} and return an iterable
+def return_iterable(string):
+	if not isinstance(string, (list, tuple)):
+		string = [string]
+
+	return string
+
 
 # Logging formatters
 


### PR DESCRIPTION
Fix #999 

@yogeshojha Maybe we should implement the function `return_iterable` to all the join used to retrieve the config values from scanEngine config ?
It needs to be tested to prevent bad behaviour

This modification is tested and working