### PR TITLE
Add missing slug in report settings saving

### DIFF
--- a/web/scanEngine/views.py
+++ b/web/scanEngine/views.py
@@ -437,7 +437,7 @@ def report_settings(request, slug):
                 request,
                 messages.INFO,
                 'Report Settings updated.')
-            return http.HttpResponseRedirect(reverse('report_settings'))
+            return http.HttpResponseRedirect(reverse('report_settings', kwargs={'slug': slug}))
 
 
     context['settings_nav_active'] = 'active'


### PR DESCRIPTION
Fix report settings saving error

```
Exception Type: 	NoReverseMatch
Exception Value: 	Reverse for 'report_settings' with no arguments not found. 1 pattern(s) tried: ['scanEngine/(?P<slug>[-a-zA-Z0-9_]+)/report_settings$']
```