### PR TITLE
Fix empty subdomain returned in nuclei scan

### DIFF
--- a/web/reNgine/common_func.py
+++ b/web/reNgine/common_func.py
@@ -447,13 +447,14 @@ def sanitize_url(http_url):
 		str: Stripped HTTP URL.
 	"""
 	# Check if the URL has a scheme. If not, add a temporary one to prevent empty netloc.
-	if "://" not in url:
-		url = "http://" + url
-
+	if "://" not in http_url:
+		http_url = "http://" + http_url
 	url = urlparse(http_url)
+	
 	if url.netloc.endswith(':80'):
 		url = url._replace(netloc=url.netloc.replace(':80', ''))
 	elif url.netloc.endswith(':443'):
+		url = url._replace(scheme=url.scheme.replace('http', 'https'))
 		url = url._replace(netloc=url.netloc.replace(':443', ''))
 	return url.geturl().rstrip('/')
 

--- a/web/reNgine/common_func.py
+++ b/web/reNgine/common_func.py
@@ -416,9 +416,12 @@ def get_subdomain_from_url(url):
 	Returns:
 		str: Subdomain name.
 	"""
+	# Check if the URL has a scheme. If not, add a temporary one to prevent empty netloc.
+	if "://" not in url:
+		url = "http://" + url
+
 	url_obj = urlparse(url.strip())
-	url_str = url_obj.netloc if url_obj.scheme else url_obj.path
-	return url_str.split(':')[0]
+	return url_obj.netloc.split(':')[0]
 
 
 def get_domain_from_subdomain(subdomain):

--- a/web/reNgine/common_func.py
+++ b/web/reNgine/common_func.py
@@ -446,6 +446,10 @@ def sanitize_url(http_url):
 	Returns:
 		str: Stripped HTTP URL.
 	"""
+	# Check if the URL has a scheme. If not, add a temporary one to prevent empty netloc.
+	if "://" not in url:
+		url = "http://" + url
+
 	url = urlparse(http_url)
 	if url.netloc.endswith(':80'):
 		url = url._replace(netloc=url.netloc.replace(':80', ''))


### PR DESCRIPTION
Fix #1008 

I've added the scheme to prevent `urlparse` to fail and return empty string