### PR TITLE
ops(docker-compose): upgrade to 2.23.0

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -60,7 +60,6 @@ else
   tput setaf 2; echo "Docker installed!!!"
 fi
 
-
 echo " "
 tput setaf 4;
 echo "#########################################################################"
@@ -74,7 +73,6 @@ else
   ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
   tput setaf 2; echo "docker-compose installed!!!"
 fi
-
 
 echo " "
 tput setaf 4;
@@ -101,8 +99,6 @@ else
   echo "You can run docker service using sudo systemctl start docker"
   exit 1
 fi
-
-
 
 echo " "
 tput setaf 4;

--- a/install.sh
+++ b/install.sh
@@ -69,7 +69,7 @@ echo "#########################################################################"
 if [ -x "$(command -v docker-compose)" ]; then
   tput setaf 2; echo "docker-compose already installed, skipping."
 else
-  curl -L "https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+  curl -L "https://github.com/docker/compose/releases/download/v2.23.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
   chmod +x /usr/local/bin/docker-compose
   ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
   tput setaf 2; echo "docker-compose installed!!!"


### PR DESCRIPTION
This brings a lot of improvements and fixes. 2.5.0 dates back from the beginning of 2022.

- Changelog for 2.23.0: https://github.com/docker/compose/releases/tag/v2.23.0
- Full changelog between 2.5.0 and 2.23.0: https://github.com/docker/compose/compare/v2.5.0...v2.23.0