### PR TITLE
Added tooltip text to dashboard total vulnerabilities tooltip

### DIFF
--- a/web/dashboard/templates/dashboard/index.html
+++ b/web/dashboard/templates/dashboard/index.html
@@ -67,7 +67,7 @@ Dashboard
 	<div class="col-xl-3 col-lg-3 col-md-6 col-sm-12 col-12">
 		<div class="card" id="tooltip-container3">
 			<div class="card-body">
-				<i class="fa fa-info-circle text-muted float-end" data-bs-container="#tooltip-container3" data-bs-toggle="tooltip" data-bs-placement="bottom" title="More Info"></i>
+				<i class="fa fa-info-circle text-muted float-end" data-bs-container="#tooltip-container3" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Total Vulnerabilities discovered by reNgine across all targets, subdomains & endpoints."></i>
 				<h4 class="mt-0 font-16 text-danger">Total Vulnerabilities</h4>
 				<h2 class="text-danger my-3 text-center"><span data-plugin="counterup">{{total_vul_count|intcomma}}</span></h2>
 				<div id="vuln_chart"></div>


### PR DESCRIPTION
Added the text:

> "Total Vulnerabilities discovered by reNgine across all targets, subdomains & endpoints."

To the tooltip icon on the Vulnerabilities Card on the Dashboard


How the label should be, following the same pattern as other tooltip labels:
![image](https://github.com/yogeshojha/rengine/assets/29872333/70da1fb8-5557-4a5d-bdc1-c33d949f9e9a)

On version 2.0.1 the tooltip label on the Total Vulnerabilities card is just a placeholder:
![image](https://github.com/yogeshojha/rengine/assets/29872333/500e8361-c641-431c-ad90-3da2211a1f2d)
