### PR TITLE
Add a check to not load datatables twice

### DIFF
--- a/web/startScan/static/startScan/js/detail_scan.js
+++ b/web/startScan/static/startScan/js/detail_scan.js
@@ -483,6 +483,9 @@ function get_osint_users(scan_id){
 }
 
 function get_screenshot(scan_id){
+	if($('#screenshots-table').children().length > 0) {
+		return false;
+	}
 	var port_array = [];
 	var service_array = [];
 	var tech_array = [];

--- a/web/startScan/static/startScan/js/detail_scan.js
+++ b/web/startScan/static/startScan/js/detail_scan.js
@@ -483,9 +483,6 @@ function get_osint_users(scan_id){
 }
 
 function get_screenshot(scan_id){
-	if($('#screenshots-table').children().length > 0) {
-		return false;
-	}
 	var port_array = [];
 	var service_array = [];
 	var tech_array = [];

--- a/web/startScan/templates/startScan/detail_scan.html
+++ b/web/startScan/templates/startScan/detail_scan.html
@@ -1536,6 +1536,11 @@ $(document).ready(function() {
 		// vulnerability datatable
 		const ps2 = new PerfectScrollbar(document.querySelector('.vulnerability-search'));
 		$("#pills-vulnerabilities-tab").click(function() {
+			// prevent table loading twice
+			// https://datatables.net/manual/tech-notes/3
+			if ( $.fn.dataTable.isDataTable( '#subdomain_scan_results' ) ) {
+				return false;
+			}
 			var is_grouping = false;
 			var grouping_col = 3;
 			var vuln_ajax_url = '/api/listVulnerability/?scan_history={{scan_history_id}}&format=datatables';
@@ -1777,6 +1782,10 @@ $(document).ready(function() {
 				});
 			});
 
+			$('#reload_vulnerabilities_table_btn').click(function () {
+				vulnerability_table.ajax.reload();
+			});
+			
 			$('#vulnerability-search-button').click(function () {
 				vulnerability_table.search($('#vulnerability-search').val()).draw() ;
 			});

--- a/web/startScan/templates/startScan/detail_scan.html
+++ b/web/startScan/templates/startScan/detail_scan.html
@@ -1034,7 +1034,7 @@ Scan Findings
 								</div>
 							</div>
 							<div class="col-12">
-								<div class="gridzy">
+								<div class="gridzy" id="screenshots-table">
 								</div>
 							</div>
 						</div>
@@ -2020,6 +2020,10 @@ $(document).ready(function() {
 
 	{% if 'screenshot' in history.tasks %}
 		$("#pills-screenshot-tab").click(function() {
+			// prevent table loading twice because it loads image twice and fails search
+			if ( $.fn.dataTable.isDataTable( '#vulnerability_results' ) ) {
+				return false;
+			}
 			get_screenshot({{scan_history_id}});
 
 			//animate search placeholder

--- a/web/startScan/templates/startScan/detail_scan.html
+++ b/web/startScan/templates/startScan/detail_scan.html
@@ -2020,8 +2020,7 @@ $(document).ready(function() {
 
 	{% if 'screenshot' in history.tasks %}
 		$("#pills-screenshot-tab").click(function() {
-			// prevent table loading twice because it loads image twice and fails search
-			if ( $.fn.dataTable.isDataTable( '#vulnerability_results' ) ) {
+			if($('#screenshots-table').children().length > 0) {
 				return false;
 			}
 			get_screenshot({{scan_history_id}});

--- a/web/startScan/templates/startScan/detail_scan.html
+++ b/web/startScan/templates/startScan/detail_scan.html
@@ -1538,7 +1538,7 @@ $(document).ready(function() {
 		$("#pills-vulnerabilities-tab").click(function() {
 			// prevent table loading twice
 			// https://datatables.net/manual/tech-notes/3
-			if ( $.fn.dataTable.isDataTable( '#subdomain_scan_results' ) ) {
+			if ( $.fn.dataTable.isDataTable( '#vulnerability_results' ) ) {
 				return false;
 			}
 			var is_grouping = false;

--- a/web/startScan/templates/startScan/detail_scan.html
+++ b/web/startScan/templates/startScan/detail_scan.html
@@ -2111,6 +2111,11 @@ $(document).ready(function() {
 	{% endif %}
 
 	$("#pills-subdomain-tab").click(function() {
+		// prevent table loading twice
+		// https://datatables.net/manual/tech-notes/3
+		if ( $.fn.dataTable.isDataTable( '#subdomain_scan_results' ) ) {
+			return false;
+		}
 		var subdomain_ajax_url = '/api/listDatatableSubdomain/?project={{current_project.slug}}&scan_id={{scan_history_id}}&format=datatables';
 		var is_subd_grouping = false;
 		var subd_grouping_col = 8;

--- a/web/startScan/templates/startScan/detail_scan.html
+++ b/web/startScan/templates/startScan/detail_scan.html
@@ -2107,6 +2107,9 @@ $(document).ready(function() {
 	});
 
 	$("#pills-visualisation-tab").click(function() {
+		if($('#visualisation').children().length > 0) {
+			return false;
+		}
 		visualise_scan_results({{scan_history_id}});
 	});
 

--- a/web/startScan/templates/startScan/vulnerabilities.html
+++ b/web/startScan/templates/startScan/vulnerabilities.html
@@ -323,6 +323,9 @@ $(document).ready(function() {
 			}
 		});
 	});
+	$('#reload_vulnerabilities_table_btn').click(function () {
+		vulnerability_table.ajax.reload();
+	});
 });
 
 var vulnerability_cols = [

--- a/web/targetApp/templates/target/summary.html
+++ b/web/targetApp/templates/target/summary.html
@@ -1342,7 +1342,7 @@ $(document).ready(function(){
 	$("#pills-vulnerabilities-tab").click(function() {
 		// prevent table loading twice
 		// https://datatables.net/manual/tech-notes/3
-		if ( $.fn.dataTable.isDataTable( '#subdomain_scan_results' ) ) {
+		if ( $.fn.dataTable.isDataTable( '#vulnerability_results' ) ) {
 			return false;
 		}
 		var is_grouping = false;

--- a/web/targetApp/templates/target/summary.html
+++ b/web/targetApp/templates/target/summary.html
@@ -903,6 +903,11 @@ $(document).ready(function(){
 	chart.render()
 
 	$("#pills-subdomain-tab").click(function() {
+		// prevent table loading twice
+		// https://datatables.net/manual/tech-notes/3
+		if ( $.fn.dataTable.isDataTable( '#subdomain_scan_results' ) ) {
+			return false;
+		}
 		var subdomain_ajax_url = '/api/listDatatableSubdomain/?project={{current_project.slug}}&scan_id={{target.id}}&format=datatables';
 		var is_subd_grouping = false;
 		var subd_grouping_col = 8;

--- a/web/targetApp/templates/target/summary.html
+++ b/web/targetApp/templates/target/summary.html
@@ -915,7 +915,7 @@ $(document).ready(function(){
 			"headerCallback": function(e, a, t, n, s) {
 				e.getElementsByTagName("th")[0].innerHTML='<div class="form-check ms-1 form-check-primary"><input type="checkbox" class="float-start form-check-input chk-parent" id="head_checkbox" onclick=mainCheckBoxSelected(this)>\n<span class="new-control-indicator"></span><span style="visibility:hidden">c</span></div>\n'
 			},
-			"destroy": true,
+			"destroy": false,
 			"processing": true,
 			"oLanguage": subdomain_oLanguage,
 			"fnCreatedRow": function (nRow, aData, iDataIndex) {
@@ -1340,11 +1340,16 @@ $(document).ready(function(){
 	});
 
 	$("#pills-vulnerabilities-tab").click(function() {
+		// prevent table loading twice
+		// https://datatables.net/manual/tech-notes/3
+		if ( $.fn.dataTable.isDataTable( '#subdomain_scan_results' ) ) {
+			return false;
+		}
 		var is_grouping = false;
 		var grouping_col = 3;
 		var vuln_ajax_url = '/api/listVulnerability/?target_id={{target.id}}&format=datatables';
 		var vulnerability_table = $('#vulnerability_results').DataTable({
-			"destroy": true,
+			"destroy": false,
 			"oLanguage": {
 				"oPaginate": {
 					"sPrevious": '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="feather feather-arrow-left"><line x1="19" y1="12" x2="5" y2="12"></line><polyline points="12 19 5 12 12 5"></polyline></svg>',

--- a/web/targetApp/templates/target/summary.html
+++ b/web/targetApp/templates/target/summary.html
@@ -1568,6 +1568,9 @@ $(document).ready(function(){
 					}
 				});
 			});
+			$('#reload_vulnerabilities_table_btn').click(function() {
+				vulnerability_table.ajax.reload();
+			});
 			// column visibility
 			vulnerability_datatable_col_visibility(vulnerability_table);
 		},

--- a/web/templates/base/_items/vulnerability_tab_content.html
+++ b/web/templates/base/_items/vulnerability_tab_content.html
@@ -87,6 +87,9 @@
 							</div>
 						</div>
 					</div>
+					<a class="btn btn-soft-primary ms-2 me-2" data-toggle="tooltip" data-placement="top" title="Reload Vulnerabilities" id="reload_vulnerabilities_table_btn">
+						<i class="fe-refresh-cw"></i>
+					</a>
 					<div class="col-12">
 						<table id="vulnerability_results" class="table dt-responsive w-100">
 							<thead>

--- a/web/templates/base/_items/vulnerability_tab_content.html
+++ b/web/templates/base/_items/vulnerability_tab_content.html
@@ -25,7 +25,7 @@
 							<button class="btn btn-soft-primary dropdown-toggle ms-1" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-toggle="tooltip" data-placement="left" title="Filter Columns">
 								<i class="fe-filter"></i>
 							</button>
-							<div class="dropdown-menu" style="">
+							<div class="dropdown-menu">
 								<div class="dropdown-item">
 									<div class="form-check">
 										<input type="checkbox" class="form-check-input" id="vuln_source_checkbox" name="vuln_source_checkbox" checked>
@@ -54,12 +54,15 @@
 									</div>
 								</div>
 							</div>
+							<a class="btn btn-soft-primary ms-2 me-2" data-toggle="tooltip" data-placement="top" title="Reload Vulnerabilities" id="reload_vulnerabilities_table_btn">
+								<i class="fe-refresh-cw"></i>
+							</a>
 						</div>
 						<div class="btn-group mb-2 float-end dropstart">
 							<button class="btn btn-soft-info dropdown-toggle ms-1" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-toggle="tooltip" data-placement="left" title="Vulnerability Grouping">
 								<i class="fe-layout"></i>
 							</button>
-							<div class="dropdown-menu" style="">
+							<div class="dropdown-menu">
 								<div class="dropdown-item">
 									<div class="form-check">
 										<input type="radio" id="vulnerability_name_grouping" name="grouping_vuln_row" class="form-check-input" value="name">
@@ -87,9 +90,6 @@
 							</div>
 						</div>
 					</div>
-					<a class="btn btn-soft-primary ms-2 me-2" data-toggle="tooltip" data-placement="top" title="Reload Vulnerabilities" id="reload_vulnerabilities_table_btn">
-						<i class="fe-refresh-cw"></i>
-					</a>
 					<div class="col-12">
 						<table id="vulnerability_results" class="table dt-responsive w-100">
 							<thead>


### PR DESCRIPTION
Fix #1038 

Add a check to not load DT twice for subdomains and vulnerabilities.
Table config is really complex and it's the quickest way to fix this.
Also it doesn't need to load table on each tab click, so it saves a lot of bandwidth on huge project

I've add a reload button on the vulnerabilities table, like the one in subdomains.

