### PR TITLE
Add flower install and expose port 5555

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,8 @@ services:
       - POSTGRES_HOST=${POSTGRES_HOST}
       - MAX_CONCURRENCY=${MAX_CONCURRENCY}
       - MIN_CONCURRENCY=${MIN_CONCURRENCY}
+    ports:
+      - "5555:5555"
     depends_on:
       - db
       - redis

--- a/web/celery-entrypoint.sh
+++ b/web/celery-entrypoint.sh
@@ -159,6 +159,8 @@ exec "$@"
 # httpx seems to have issue, use alias instead!!!
 echo 'alias httpx="/go/bin/httpx"' >> ~/.bashrc
 
+# Install web interface to mnitor celery task (for debug)
+python3 -m pip install flower
 
 # watchmedo auto-restart --recursive --pattern="*.py" --directory="/usr/src/app/reNgine/" -- celery -A reNgine.tasks worker --autoscale=10,0 -l INFO -Q scan_queue &
 echo "Starting Workers..."


### PR DESCRIPTION
fix #1042 

https://docs.celeryq.dev/en/latest/userguide/monitoring.html

![image](https://github.com/yogeshojha/rengine/assets/1230954/36d47b53-5803-47d6-ba20-b599e9b55988)

https://medium.com/featurepreneur/flower-celery-monitoring-tool-50fba1c8f623

> Flower

> A flower is a web-based tool for monitoring and administrating Celery clusters. It has a UI that monitors all the workers on celery. It gives clear statistics on the active tasks, processed tasks showing whether the task was successful or not, and also tells the load average of the tasks. It also maintains the name of the task, the arguments, the result, and the time taken to complete the task.

**Flower is not started by default**

You need to go inside the celery container and launch flower manually
```sh
docker exec -it rengine_celery /usr/bin/bash
root@e76c97c4be38:/usr/src/app# celery flower
```

Maybe we could enable it by default to give the facility to kill worker when needed ?