### PR TITLE
Upgrade project discovery tool at CT build

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -91,6 +91,13 @@ RUN go install -v github.com/sa7mon/s3scanner@latest
 RUN nuclei -update
 RUN nuclei -update-templates
 
+# Update project discovery tools
+RUN httpx -up
+RUN naabu -up
+RUN subfinder -up
+RUN tlsx -up
+RUN katana -up
+
 # Copy requirements
 COPY ./requirements.txt /tmp/requirements.txt
 RUN pip3 install --upgrade setuptools pip && \


### PR DESCRIPTION
There are some problems with Project Discovery tools
When installing tools, some are not up to date with the latest version.
The most important one is HTTPx, because scan can't start if no endpoint found.

1.3.6 has problems with `-asn` paramater that makes crash it
https://github.com/projectdiscovery/httpx/issues/1442

There's a lot of feedback on discord for this issue.

So it's important to have the most up to date Project Discovery tool when creating celery container.