### PR TITLE
Fix crash on saving endpoint (FFUF related only)

### DIFF
--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -1666,7 +1666,6 @@ def dir_file_fuzz(self, ctx={}, description=None):
 				logger.error(f'FUZZ not found for "{url}"')
 				continue
 			endpoint, created = save_endpoint(url, crawl=False, ctx=ctx)
-			# endpoint.is_default = False
 			endpoint.http_status = status
 			endpoint.content_length = length
 			endpoint.response_time = duration / 1000000000

--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -4503,7 +4503,7 @@ def save_endpoint(
 				http_url=http_url,
 				**endpoint_data)
 		except Exception as e:
-			logger.error(f'/!\ - URL : '+http_url+', exception: '+e)
+			logger.error(f'/!\ - URL : '+http_url+', exception: '+str(e))
 			return None, False
 
 	if created:

--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -1666,38 +1666,37 @@ def dir_file_fuzz(self, ctx={}, description=None):
 				logger.error(f'FUZZ not found for "{url}"')
 				continue
 			endpoint, created = save_endpoint(url, crawl=False, ctx=ctx)
-			if endpoint:
-				# endpoint.is_default = False
-				endpoint.http_status = status
-				endpoint.content_length = length
-				endpoint.response_time = duration / 1000000000
-				endpoint.save()
-				if created:
-					urls.append(endpoint.http_url)
-				endpoint.status = status
-				endpoint.content_type = content_type
-				endpoint.content_length = length
-				dfile, created = DirectoryFile.objects.get_or_create(
-					name=name,
-					length=length,
-					words=words,
-					lines=lines,
-					content_type=content_type,
-					url=url)
-				dfile.http_status = status
-				dfile.save()
-				# if created:
-				# 	logger.warning(f'Found new directory or file {url}')
-				dirscan.directory_files.add(dfile)
-				dirscan.save()
+			# endpoint.is_default = False
+			endpoint.http_status = status
+			endpoint.content_length = length
+			endpoint.response_time = duration / 1000000000
+			endpoint.save()
+			if created:
+				urls.append(endpoint.http_url)
+			endpoint.status = status
+			endpoint.content_type = content_type
+			endpoint.content_length = length
+			dfile, created = DirectoryFile.objects.get_or_create(
+				name=name,
+				length=length,
+				words=words,
+				lines=lines,
+				content_type=content_type,
+				url=url)
+			dfile.http_status = status
+			dfile.save()
+			# if created:
+			# 	logger.warning(f'Found new directory or file {url}')
+			dirscan.directory_files.add(dfile)
+			dirscan.save()
 
-				if self.subscan:
-					dirscan.dir_subscan_ids.add(self.subscan)
+			if self.subscan:
+				dirscan.dir_subscan_ids.add(self.subscan)
 
-				subdomain_name = get_subdomain_from_url(endpoint.http_url)
-				subdomain = Subdomain.objects.get(name=subdomain_name, scan_history=self.scan)
-				subdomain.directories.add(dirscan)
-				subdomain.save()
+			subdomain_name = get_subdomain_from_url(endpoint.http_url)
+			subdomain = Subdomain.objects.get(name=subdomain_name, scan_history=self.scan)
+			subdomain.directories.add(dirscan)
+			subdomain.save()
 
 	# Crawl discovered URLs
 	if enable_http_crawl:
@@ -4496,15 +4495,26 @@ def save_endpoint(
 		if not validators.url(http_url):
 			return None, False
 		http_url = sanitize_url(http_url)
-		try:
+
+		# Try to get the first matching record (prevent duplicate error)
+		endpoints = EndPoint.objects.filter(
+			scan_history=scan,
+			target_domain=domain,
+			http_url=http_url,
+			**endpoint_data
+		)
+
+		if endpoints.exists():
+			endpoint = endpoints.first()
+			created = False
+		else:
+			# No existing record, create a new one
 			endpoint, created = EndPoint.objects.get_or_create(
 				scan_history=scan,
 				target_domain=domain,
 				http_url=http_url,
-				**endpoint_data)
-		except Exception as e:
-			logger.error(f'/!\ - URL : '+http_url+', exception: '+str(e))
-			return None, False
+				**endpoint_data
+			)
 
 	if created:
 		endpoint.is_default = is_default

--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -4509,7 +4509,7 @@ def save_endpoint(
 			created = False
 		else:
 			# No existing record, create a new one
-			endpoint, created = EndPoint.objects.get_or_create(
+			endpoint, created = EndPoint.objects.create(
 				scan_history=scan,
 				target_domain=domain,
 				http_url=http_url,

--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -4496,8 +4496,6 @@ def save_endpoint(
 		if not validators.url(http_url):
 			return None, False
 		http_url = sanitize_url(http_url)
-		if os.environ.get('DEBUG'):
-			logger.warning(f'================== URL : '+http_url)
 		try:
 			endpoint, created = EndPoint.objects.get_or_create(
 				scan_history=scan,
@@ -4505,7 +4503,7 @@ def save_endpoint(
 				http_url=http_url,
 				**endpoint_data)
 		except Exception as e:
-			logger.error(e)
+			logger.error(f'/!\ - URL : '+http_url+', exception: '+e)
 			return None, False
 
 	if created:

--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -1666,37 +1666,38 @@ def dir_file_fuzz(self, ctx={}, description=None):
 				logger.error(f'FUZZ not found for "{url}"')
 				continue
 			endpoint, created = save_endpoint(url, crawl=False, ctx=ctx)
-			# endpoint.is_default = False
-			endpoint.http_status = status
-			endpoint.content_length = length
-			endpoint.response_time = duration / 1000000000
-			endpoint.save()
-			if created:
-				urls.append(endpoint.http_url)
-			endpoint.status = status
-			endpoint.content_type = content_type
-			endpoint.content_length = length
-			dfile, created = DirectoryFile.objects.get_or_create(
-				name=name,
-				length=length,
-				words=words,
-				lines=lines,
-				content_type=content_type,
-				url=url)
-			dfile.http_status = status
-			dfile.save()
-			# if created:
-			# 	logger.warning(f'Found new directory or file {url}')
-			dirscan.directory_files.add(dfile)
-			dirscan.save()
+			if endpoint:
+				# endpoint.is_default = False
+				endpoint.http_status = status
+				endpoint.content_length = length
+				endpoint.response_time = duration / 1000000000
+				endpoint.save()
+				if created:
+					urls.append(endpoint.http_url)
+				endpoint.status = status
+				endpoint.content_type = content_type
+				endpoint.content_length = length
+				dfile, created = DirectoryFile.objects.get_or_create(
+					name=name,
+					length=length,
+					words=words,
+					lines=lines,
+					content_type=content_type,
+					url=url)
+				dfile.http_status = status
+				dfile.save()
+				# if created:
+				# 	logger.warning(f'Found new directory or file {url}')
+				dirscan.directory_files.add(dfile)
+				dirscan.save()
 
-			if self.subscan:
-				dirscan.dir_subscan_ids.add(self.subscan)
+				if self.subscan:
+					dirscan.dir_subscan_ids.add(self.subscan)
 
-			subdomain_name = get_subdomain_from_url(endpoint.http_url)
-			subdomain = Subdomain.objects.get(name=subdomain_name, scan_history=self.scan)
-			subdomain.directories.add(dirscan)
-			subdomain.save()
+				subdomain_name = get_subdomain_from_url(endpoint.http_url)
+				subdomain = Subdomain.objects.get(name=subdomain_name, scan_history=self.scan)
+				subdomain.directories.add(dirscan)
+				subdomain.save()
 
 	# Crawl discovered URLs
 	if enable_http_crawl:
@@ -4495,11 +4496,17 @@ def save_endpoint(
 		if not validators.url(http_url):
 			return None, False
 		http_url = sanitize_url(http_url)
-		endpoint, created = EndPoint.objects.get_or_create(
-			scan_history=scan,
-			target_domain=domain,
-			http_url=http_url,
-			**endpoint_data)
+		if os.environ.get('DEBUG')
+			logger.warning(f'================== URL : '+http_url+' 						==================')
+		try:
+			endpoint, created = EndPoint.objects.get_or_create(
+				scan_history=scan,
+				target_domain=domain,
+				http_url=http_url,
+				**endpoint_data)
+		except Exception as e:
+			logger.error(e)
+			return None, False
 
 	if created:
 		endpoint.is_default = is_default

--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -4509,12 +4509,13 @@ def save_endpoint(
 			created = False
 		else:
 			# No existing record, create a new one
-			endpoint, created = EndPoint.objects.create(
+			endpoint = EndPoint.objects.create(
 				scan_history=scan,
 				target_domain=domain,
 				http_url=http_url,
 				**endpoint_data
 			)
+			created = True
 
 	if created:
 		endpoint.is_default = is_default

--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -4497,7 +4497,7 @@ def save_endpoint(
 			return None, False
 		http_url = sanitize_url(http_url)
 		if os.environ.get('DEBUG'):
-			logger.warning(f'================== URL : '+http_url+' 						==================')
+			logger.warning(f'================== URL : '+http_url)
 		try:
 			endpoint, created = EndPoint.objects.get_or_create(
 				scan_history=scan,

--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -4496,7 +4496,7 @@ def save_endpoint(
 		if not validators.url(http_url):
 			return None, False
 		http_url = sanitize_url(http_url)
-		if os.environ.get('DEBUG')
+		if os.environ.get('DEBUG'):
 			logger.warning(f'================== URL : '+http_url+' 						==================')
 		try:
 			endpoint, created = EndPoint.objects.get_or_create(


### PR DESCRIPTION
Fix #1006 

I've added :
- a **try except** block to catch error on duplicate record returned by **get_or_create** in **saving_endpoint** method
- a **check** on endpoint existence in **dir_file_fuzz** method

Errors are logged to the console with the URL.

![image](https://github.com/yogeshojha/rengine/assets/1230954/3067c8a3-f44d-4b8f-b048-d1a356d542a2)

Tested and working

Now we need to find why there are duplicates endpoints in the db
But it's another issue