### PR TITLE
ops(`uninstall.sh`): fix incorrect container names and add missing volumes

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -11,7 +11,7 @@ if [ "$EUID" -ne 0 ]
 fi
 
 echo "Stopping reNgine"
-docker stop rengine_web_1 rengine_db_1 rengine_celery_1 rengine_celery-beat_1 rengine_redis_1 rengine_tor_1 rengine_proxy_1
+docker stop rengine-web-1 rengine-db-1 rengine-celery-1 rengine-celery-beat-1 rengine-redis-1 rengine-tor-1 rengine-proxy-1
 
 if [[ $REPLY =~ ^[Yy]$ ]]
 then

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -10,9 +10,6 @@ if [ "$EUID" -ne 0 ]
   exit
 fi
 
-echo "Stopping reNgine"
-docker stop rengine-web-1 rengine-db-1 rengine-celery-1 rengine-celery-beat-1 rengine-redis-1 rengine-tor-1 rengine-proxy-1
-
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
   echo "Stopping reNgine"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -34,4 +34,4 @@ else
   exit 1
 fi
 
-echo "Finished Uninstalling."
+echo "Finished uninstalling."


### PR DESCRIPTION
Previous PR: https://github.com/yogeshojha/rengine/pull/880

# Fixes

- **Incorrect container names:** the incorrect container names caused that the containers, volumes and networks weren't being removed as it requires the containers to be stopped
- **reNgine art not showing:** this was caused by the incorrect filename (`rengine.txt` instead of `reNgine.txt`)

**Before:**

![image](https://user-images.githubusercontent.com/50231698/232302674-0b8f0b0a-ce32-43c2-b056-ba2b3a94c95e.png)

**After:**

![image](https://user-images.githubusercontent.com/50231698/232302804-d285fce3-2c7c-4bc3-a364-3cc1ce38cc06.png)
