### PR TITLE
chore(issue-templates): incorrect label name

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,7 +1,7 @@
 name: 🐞 Bug
 description: File a bug/issue
 title: "bug: <title>"
-labels: [Bug, Needs Triage]
+labels: [bug]
 body:
 - type: checkboxes
   attributes:


### PR DESCRIPTION
This caused bug reports to not have an automatic label assigned.