### PR TITLE
Nmap port scan fails when Naabu return no port

### DIFF
--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -1372,6 +1372,12 @@ def port_scan(self, hosts=[], ctx={}, description=None):
 		# Send notification
 		logger.warning(f'Found opened port {port_number} on {ip_address} ({host})')
 
+	if len(ports_data) == 0:
+		logger.info('Finished running naabu port scan - No open ports found.')
+		if nmap_enabled:
+			logger.info('Nmap scans skipped')
+		return ports_data
+
 	# Send notification
 	fields_str = ''
 	for host, ports in ports_data.items():


### PR DESCRIPTION
While launching a port scan with Naabu + Nmap, I experienced a crash if Naabu returns no port
```
rengine-celery-1       | nmap                               | ERROR | 'NoneType' object is not subscriptable
rengine-celery-1       | Traceback (most recent call last):
rengine-celery-1       |   File "/usr/src/app/reNgine/celery_custom_task.py", line 129, in __call__
rengine-celery-1       |     self.result = self.run(*args, **kwargs)
rengine-celery-1       |   File "/usr/src/app/reNgine/tasks.py", line 1481, in nmap
rengine-celery-1       |     vulns = parse_nmap_results(output_file_xml, output_file)
rengine-celery-1       |   File "/usr/local/lib/python3.10/dist-packages/celery/local.py", line 182, in __call__
rengine-celery-1       |     return self._get_current_object()(*a, **kw)
rengine-celery-1       |   File "/usr/local/lib/python3.10/dist-packages/celery/app/trace.py", line 761, in __protected_call__
rengine-celery-1       |     return orig(self, *args, **kwargs)
rengine-celery-1       |   File "/usr/local/lib/python3.10/dist-packages/celery/app/task.py", line 411, in __call__
rengine-celery-1       |     return self.run(*args, **kwargs)
rengine-celery-1       |   File "/usr/src/app/reNgine/tasks.py", line 3198, in parse_nmap_results
rengine-celery-1       |     hostnames = [host.get('address')['@addr']]
```

So I've added a check on empty port scan to prevent Nmap launch
![image](https://github.com/yogeshojha/rengine/assets/1230954/8ec441f8-5693-4f03-bcf5-4d5ea5f102e2)

Tested and working on my use case