### PR TITLE
Add missing domain id value in subscan

### DIFF
--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -220,9 +220,10 @@ def initiate_subscan(
 		url_filter (str): URL path. Default: ''
 	"""
 
-	# Get Subdomain and ScanHistory
+	# Get Subdomain, Domain and ScanHistory
 	subdomain = Subdomain.objects.get(pk=subdomain_id)
 	scan = ScanHistory.objects.get(pk=subdomain.scan_history.id)
+	domain = Domain.objects.get(pk=subdomain.target_domain.id)
 
 	# Get EngineType
 	engine_id = engine_id or scan.scan_type.id
@@ -270,6 +271,7 @@ def initiate_subscan(
 		'scan_history_id': scan.id,
 		'subscan_id': subscan.id,
 		'engine_id': engine_id,
+		'domain_id': domain.id,
 		'subdomain_id': subdomain.id,
 		'yaml_configuration': config,
 		'results_dir': results_dir,


### PR DESCRIPTION
Related to #1041 

In database there is a lot of endpoints which does not have a target_domain_id value.
It generates a lot of duplicates and can cause scan to fail, bad count (see #1041) and a lot of side effects
![image](https://github.com/yogeshojha/rengine/assets/1230954/f1a5c950-8105-427b-b67e-5443bf7b6095)

This PR fix missing domain_id value while launching a subscan

This fix definitively #1040 

For those who wants to correctly count their endpoints previously scanned on target page, you need to update the target id of endpoints in the database

```sql
UPDATE public."startScan_endpoint"
set target_domain_id=1
where http_url like '%http_urls_to_update_here%'
```