### PR TITLE
Endpoints list popup empty

### DIFF
--- a/web/api/views.py
+++ b/web/api/views.py
@@ -2141,7 +2141,7 @@ class EndPointViewSet(viewsets.ModelViewSet):
 			endpoints = endpoints.filter(matched_gf_patterns__icontains=gf_tag)
 
 		if target_id:
-			endpoints = endpoints.filter(target__id=target_id)
+			endpoints = endpoints.filter(target_domain__id=target_id)
 
 		if subdomain_id:
 			endpoints = endpoints.filter(subdomain__id=subdomain_id)

--- a/web/api/views.py
+++ b/web/api/views.py
@@ -2116,7 +2116,12 @@ class EndPointViewSet(viewsets.ModelViewSet):
 		subdomain_id = req.query_params.get('subdomain_id')
 		project = req.query_params.get('project')
 
-		endpoints_obj = EndPoint.objects.filter(scan_history__domain__project__slug=project)
+		if project:
+			endpoints_obj = EndPoint.objects.filter(scan_history__domain__project__slug=project)
+		elif target_id:
+			endpoints_obj = EndPoint.objects.filter(target__id=target_id)
+		elif subdomain_id:
+			endpoints_obj = EndPoint.objects.filter(subdomain__id=subdomain_id)
 
 		gf_tag = req.query_params.get(
 			'gf_tag') if 'gf_tag' in req.query_params else None

--- a/web/api/views.py
+++ b/web/api/views.py
@@ -2116,10 +2116,7 @@ class EndPointViewSet(viewsets.ModelViewSet):
 		subdomain_id = req.query_params.get('subdomain_id')
 		project = req.query_params.get('project')
 
-		if project:
-			endpoints_obj = EndPoint.objects.filter(scan_history__domain__project__slug=project)
-		elif target_id:
-			endpoints_obj = EndPoint.objects.filter(target__id=target_id)
+		endpoints_obj = EndPoint.objects.filter(scan_history__domain__project__slug=project)
 
 		gf_tag = req.query_params.get(
 			'gf_tag') if 'gf_tag' in req.query_params else None
@@ -2142,6 +2139,9 @@ class EndPointViewSet(viewsets.ModelViewSet):
 
 		if gf_tag:
 			endpoints = endpoints.filter(matched_gf_patterns__icontains=gf_tag)
+
+		if target_id:
+			endpoints = endpoints.filter(target__id=target_id)
 
 		if subdomain_id:
 			endpoints = endpoints.filter(subdomain__id=subdomain_id)

--- a/web/api/views.py
+++ b/web/api/views.py
@@ -2120,8 +2120,6 @@ class EndPointViewSet(viewsets.ModelViewSet):
 			endpoints_obj = EndPoint.objects.filter(scan_history__domain__project__slug=project)
 		elif target_id:
 			endpoints_obj = EndPoint.objects.filter(target__id=target_id)
-		elif subdomain_id:
-			endpoints_obj = EndPoint.objects.filter(subdomain__id=subdomain_id)
 
 		gf_tag = req.query_params.get(
 			'gf_tag') if 'gf_tag' in req.query_params else None

--- a/web/startScan/static/startScan/js/detail_scan.js
+++ b/web/startScan/static/startScan/js/detail_scan.js
@@ -933,7 +933,7 @@ function get_vulnerability_modal(scan_id=null, severity=null, subdomain_id=null,
 }
 
 
-function get_endpoint_modal(scan_id, subdomain_id, subdomain_name){
+function get_endpoint_modal(project, scan_id, subdomain_id, subdomain_name){
 	// This function will display a xl modal with datatable for displaying endpoints
 	// associated with the subdomain
 	$('#xl-modal-title').empty();
@@ -941,10 +941,10 @@ function get_endpoint_modal(scan_id, subdomain_id, subdomain_name){
 	$('#xl-modal-footer').empty();
 
 	if (scan_id) {
-		url = `/api/listEndpoints/?scan_id=${scan_id}&subdomain_id=${subdomain_id}&format=json`
+		url = `/api/listEndpoints/?project=${project}&scan_id=${scan_id}&subdomain_id=${subdomain_id}&format=json`
 	}
 	else{
-		url = `/api/listEndpoints/?subdomain_id=${subdomain_id}&format=json`
+		url = `/api/listEndpoints/?project=${project}&subdomain_id=${subdomain_id}&format=json`
 	}
 
 	Swal.fire({

--- a/web/startScan/templates/startScan/detail_scan.html
+++ b/web/startScan/templates/startScan/detail_scan.html
@@ -2214,7 +2214,7 @@ $(document).ready(function() {
 
 							endpoint_count_badge = '';
 							if (row['endpoint_count']) {
-								endpoint_count_badge = `<span class="pl-2 pr-2 me-1 badge badge-soft-primary badge-link bs-tooltip" title="Endpoints" onclick="get_endpoint_modal({{history.id}}, ${row['id']}, '${row['name']}')">${row['endpoint_count']} <i class=" fas fa-link"></i></span>`;
+								endpoint_count_badge = `<span class="pl-2 pr-2 me-1 badge badge-soft-primary badge-link bs-tooltip" title="Endpoints" onclick="get_endpoint_modal('{{current_project.slug}}', {{history.id}}, ${row['id']}, '${row['name']}')">${row['endpoint_count']} <i class=" fas fa-link"></i></span>`;
 							}
 
 							if(row['waf'].length){

--- a/web/startScan/templates/startScan/subdomains.html
+++ b/web/startScan/templates/startScan/subdomains.html
@@ -125,7 +125,7 @@ $(document).ready(function() {
 
 						endpoint_count_badge = '';
 						if (row['endpoint_count']) {
-							endpoint_count_badge = `<span class="pl-2 pr-2 me-1 badge badge-soft-primary badge-link bs-tooltip" title="Endpoints" onclick="get_endpoint_modal(scan_id=null, subdomain_id=${row['id']}, '${row['name']}')">${row['endpoint_count']} <i class=" fas fa-link"></i></span>`;
+							endpoint_count_badge = `<span class="pl-2 pr-2 me-1 badge badge-soft-primary badge-link bs-tooltip" title="Endpoints" onclick="get_endpoint_modal(project='{{current_project.slug}}', scan_id=null, subdomain_id=${row['id']}, '${row['name']}')">${row['endpoint_count']} <i class=" fas fa-link"></i></span>`;
 						}
 
 						if(row['waf'].length){

--- a/web/targetApp/templates/target/summary.html
+++ b/web/targetApp/templates/target/summary.html
@@ -991,7 +991,7 @@ $(document).ready(function(){
 
 							endpoint_count_badge = '';
 							if (row['endpoint_count']) {
-								endpoint_count_badge = `<span class="pl-2 pr-2 me-1 badge badge-soft-primary badge-link bs-tooltip" title="Endpoints" onclick="get_endpoint_modal(null, ${row['id']}, '${row['name']}')">${row['endpoint_count']} <i class=" fas fa-link"></i></span>`;
+								endpoint_count_badge = `<span class="pl-2 pr-2 me-1 badge badge-soft-primary badge-link bs-tooltip" title="Endpoints" onclick="get_endpoint_modal('{{current_project.slug}}', null, ${row['id']}, '${row['name']}')">${row['endpoint_count']} <i class=" fas fa-link"></i></span>`;
 							}
 
 							if(row['waf'].length){


### PR DESCRIPTION
In certain case, endpoints popup list is empty.
After research I saw that some url pointing to endpoint list miss the **project** parameter causing the base query which fetch the datas returns empty result
```
endpoints_obj = EndPoint.objects.filter(scan_history__domain__project__slug=project)
```
I've added some conditions to fit to the parameters possibilities and set the **project** parameter on all links

Endpoint display in all case well now