### PR TITLE
IOError -> OSError

### DIFF
--- a/web/reNgine/init.py
+++ b/web/reNgine/init.py
@@ -22,7 +22,7 @@ def first_run(secret_file, base_dir):
             secret = open(secret_file, 'w')
             secret.write(secret_key)
             secret.close()
-        except IOError:
+        except OSError:
             raise Exception(f'Secret file generation failed. Path: {secret_file}')
     return secret_key
 


### PR DESCRIPTION
IOError has been deprecated in Python version 3.3: 

> EnvironmentError, IOError, WindowsError, VMSError, socket.error, select.error and mmap.error have been merged into OSError