### PR TITLE
feat(admin_settings): show role description users

### DIFF
--- a/web/dashboard/templates/dashboard/admin.html
+++ b/web/dashboard/templates/dashboard/admin.html
@@ -216,7 +216,7 @@ function update_user_modal(user_id, permission){
           .catch(function() {
             swal.insertQueueStep({
               type: 'error',
-              title: 'Oops! Unable to updte user!'
+              title: 'Oops! Unable to update user!'
             })
           })
           resolve()
@@ -314,7 +314,7 @@ function create_user_modal(){
           .catch(function() {
             swal.insertQueueStep({
               type: 'error',
-              title: 'Oops! Unable to updte user!'
+              title: 'Oops! Unable to update user!'
             })
           })
           resolve()

--- a/web/dashboard/templates/dashboard/admin.html
+++ b/web/dashboard/templates/dashboard/admin.html
@@ -246,6 +246,9 @@ function create_user_modal(){
     <label for="create_username" class="form-label float-start">Username</label>
     <input id="create_username" class="form-control" placeholder="Username" autocomplete="off">
   </div>
+  <i class="fa fa-info-circle text-muted float-end" data-bs-container="#tooltip-container" data-bs-toggle="tooltip" data-bs-placement="bottom" title="- Sys Admin: Sys Admin is a super user that has permission to modify system and scan related configurations, scan engines, create new users, add new tools etc. Super user can initiate scans and subscans effortlessly.
+- Penetration Tester: Penetration Tester will be allowed to modify and initiate scans and subscans, add or update targets, etc. A penetration tester will not be allowed to modify system configurations.
+- Auditor: Auditor can only view and download the report. An auditor can not change any system or scan related configurations nor can initiate any scans or subscans."></i>
   <div class="form mb-3">
     <label for="create_user_role" class="form-label float-start">Role</label>
     <select class="form-select" id="create_user_role">


### PR DESCRIPTION
It's important for pentesters to know the differences between the roles, which is why I described the differences (from https://github.com/yogeshojha/rengine?tab=readme-ov-file#about-rengine) in a tooltip. I think using a tooltip is fine, or at least better than showing all of that text at once.

Unsure whether this should be part of 2.1.0 or 2.0.2.

![image](https://github.com/yogeshojha/rengine/assets/50231698/c98b01fe-9f10-4f0c-819e-fa9183a61d1d)