### PR TITLE
Fix report generation when `Ignore Informational Vulnerabilities` checked

### DIFF
--- a/web/startScan/models.py
+++ b/web/startScan/models.py
@@ -263,6 +263,13 @@ class Subdomain(models.Model):
 		return vulns
 
 	@property
+	def get_vulnerabilities_without_info(self):
+		vulns = Vulnerability.objects.filter(subdomain__name=self.name).exclude(severity=0)
+		if self.scan_history:
+			vulns = vulns.filter(scan_history=self.scan_history)
+		return vulns
+
+	@property
 	def get_directories_count(self):
 		subdomains = (
 			Subdomain.objects

--- a/web/startScan/views.py
+++ b/web/startScan/views.py
@@ -908,6 +908,7 @@ def create_report(request, id):
         'scan_object': scan,
         'unique_vulnerabilities': unique_vulns,
         'all_vulnerabilities': vulns,
+        'all_vulnerabilities_count': vulns.count(),
         'subdomain_alive_count': subdomain_alive_count,
         'interesting_subdomains': interesting_subdomains,
         'subdomains': subdomains,
@@ -915,6 +916,7 @@ def create_report(request, id):
         'show_recon': show_recon,
         'show_vuln': show_vuln,
         'report_name': report_name,
+        'is_ignore_info_vuln': is_ignore_info_vuln,
     }
 
     # Get report related config

--- a/web/templates/report/template.html
+++ b/web/templates/report/template.html
@@ -934,106 +934,106 @@
       {% if show_vuln %}
         <article class="">
           {% regroup all_vulnerabilities by get_path as grouped_vulnerabilities %}
-          {% for vulnerability in grouped_vulnerabilities %}
-            <div>
-              <h4 class="content-heading" id="vuln_{{vulnerability.list.0.name.split|join:'_'}}">
-                <span>{{vulnerability.list.0.name}}
-                  <br>in {{vulnerability.grouper}}</span>
-                {% if vulnerability.list.0.severity == -1 %}
-                  <span style="float: right;" class="badge bg-grey">Unknown</span>
-                  <div class="grey-hr-line" ></div>
-                {% elif vulnerability.list.0.severity == 0 %}
-                  <span style="float: right;" class="badge bg-info">INFO</span>
-                  <div class="info-hr-line" ></div>
-                {% elif vulnerability.list.0.severity == 1 %}
-                  <span style="float: right;" class="badge bg-low">LOW</span>
-                  <div class="low-hr-line" ></div>
-                {% elif vulnerability.list.0.severity == 2 %}
-                  <span style="float: right;" class="badge bg-medium">MEDIUM</span>
-                  <div class="medium-hr-line" ></div>
-                {% elif vulnerability.list.0.severity == 3 %}
-                  <span style="float: right;" class="badge bg-high">HIGH</span>
-                  <div class="high-hr-line" ></div>
-                {% elif vulnerability.list.0.severity == 4 %}
-                  <span style="float: right;" class="badge bg-critical">CRITICAL</span>
-                  <div class="critical-hr-line" ></div>
+          {% for vulnerabilities in grouped_vulnerabilities %}
+            {% for vulnerability in vulnerabilities.list %}
+              <div>
+                <h4 class="content-heading" id="vuln_{{vulnerability.name.split|join:'_'}}">
+                  <span>{{vulnerability.name}}
+                    <br>in {{vulnerabilities.grouper}}</span>
+                  {% if vulnerability.severity == -1 %}
+                    <span style="float: right;" class="badge bg-grey">Unknown</span>
+                    <div class="grey-hr-line" ></div>
+                  {% elif vulnerability.severity == 0 %}
+                    <span style="float: right;" class="badge bg-info">INFO</span>
+                    <div class="info-hr-line" ></div>
+                  {% elif vulnerability.severity == 1 %}
+                    <span style="float: right;" class="badge bg-low">LOW</span>
+                    <div class="low-hr-line" ></div>
+                  {% elif vulnerability.severity == 2 %}
+                    <span style="float: right;" class="badge bg-medium">MEDIUM</span>
+                    <div class="medium-hr-line" ></div>
+                  {% elif vulnerability.severity == 3 %}
+                    <span style="float: right;" class="badge bg-high">HIGH</span>
+                    <div class="high-hr-line" ></div>
+                  {% elif vulnerability.severity == 4 %}
+                    <span style="float: right;" class="badge bg-critical">CRITICAL</span>
+                    <div class="critical-hr-line" ></div>
+                  {% endif %}
+                </h4>
+                <!-- show vulnerability classification -->
+                <span class="mini-heading">Vulnerability Source: {{vulnerability.source|upper}}</span><br>
+                {% if vulnerability.cvss_metrics or vulnerability.cvss_score or vulnerability.cve_ids.all or vulnerability.cve_ids.all %}
+                  <span class="mini-heading">Vulnerability Classification</span><br>
+                  {% if vulnerability.cvss_metrics %}
+                    <span class="mini-heading ml-8">CVSS Metrics: {{vulnerability.cvss_metrics}}</span>
+                  {% endif %}
+                  {% if vulnerability.cvss_score %}
+                  <br>
+                    <span class="mini-heading ml-8">CVSS Score:</span>&nbsp;<span class="high-color">{{vulnerability.cvss_score}}</span>
+                  {% endif %}
+                  {% if vulnerability.cve_ids.all %}
+                  <br>
+                  <span class="mini-heading ml-8">CVE IDs</span><br>
+                    &nbsp;&nbsp;&nbsp;&nbsp;{% for cve in vulnerability.cve_ids.all %} {{cve}}{% if not forloop.last %}, {% endif %} {% endfor %}
+                  {% endif %}
+                  {% if vulnerability.cwe_ids.all %}
+                  <br>
+                  <span class="mini-heading ml-8">CWE IDs</span><br>
+                    &nbsp;&nbsp;&nbsp;&nbsp;{% for cwe in vulnerability.cwe_ids.all %} {{cwe}}{% if not forloop.last %}, {% endif %} {% endfor %}
+                  {% endif %}
+                  <br>
                 {% endif %}
-              </h4>
-              <!-- show vulnerability classification -->
-              <span class="mini-heading">Vulnerability Source: {{vulnerability.list.0.source|upper}}</span><br>
-              {% if vulnerability.list.0.cvss_metrics or vulnerability.list.0.cvss_score or vulnerability.list.0.cve_ids.all or vulnerability.list.0.cve_ids.all %}
-                <span class="mini-heading">Vulnerability Classification</span><br>
-                {% if vulnerability.list.0.cvss_metrics %}
-                  <span class="mini-heading ml-8">CVSS Metrics: {{vulnerability.list.0.cvss_metrics}}</span>
+                {% if vulnerability.description %}
+                  <br>
+                  <span class="mini-heading">Description</span><br>
+                  {{vulnerability.description|linebreaks}}
                 {% endif %}
-                {% if vulnerability.list.0.cvss_score %}
-                <br>
-                  <span class="mini-heading ml-8">CVSS Score:</span>&nbsp;<span class="high-color">{{vulnerability.list.0.cvss_score}}</span>
+                {% if vulnerability.impact %}
+                  <br>
+                  <span class="mini-heading">Impact</span><br>
+                  {{vulnerability.impact|linebreaks}}
                 {% endif %}
-                {% if vulnerability.list.0.cve_ids.all %}
-                <br>
-                <span class="mini-heading ml-8">CVE IDs</span><br>
-                  &nbsp;&nbsp;&nbsp;&nbsp;{% for cve in vulnerability.list.0.cve_ids.all %} {{cve}}{% if not forloop.last %}, {% endif %} {% endfor %}
-                {% endif %}
-                {% if vulnerability.list.0.cwe_ids.all %}
-                <br>
-                <span class="mini-heading ml-8">CWE IDs</span><br>
-                  &nbsp;&nbsp;&nbsp;&nbsp;{% for cwe in vulnerability.list.0.cwe_ids.all %} {{cwe}}{% if not forloop.last %}, {% endif %} {% endfor %}
+                {% if vulnerability.remediation %}
+                  <br>
+                  <span class="mini-heading">Remediation</span><br>
+                  {{vulnerability.remediation|linebreaks}}
                 {% endif %}
                 <br>
-              {% endif %}
-              {% if vulnerability.list.0.description %}
-                <br>
-                <span class="mini-heading">Description</span><br>
-                {{vulnerability.list.0.description|linebreaks}}
-              {% endif %}
-              {% if vulnerability.list.0.impact %}
-                <br>
-                <span class="mini-heading">Impact</span><br>
-                {{vulnerability.list.0.impact|linebreaks}}
-              {% endif %}
-              {% if vulnerability.list.0.remediation %}
-                <br>
-                <span class="mini-heading">Remediation</span><br>
-                {{vulnerability.list.0.remediation|linebreaks}}
-              {% endif %}
-              <br>
-              <span class="mini-heading">Vulnerable URL(s)</span><br>
-              <ul>
-                {% for vuln in vulnerability.list %}
-                  <li class="text-blue">{{vuln.http_url}}</li>
-                {% endfor %}
-              </ul>
-              <!-- {% regroup vulnerability.list by http_url as vuln_http_url_list %} -->
-              <!-- <ul>
-                {% for vuln_urls in vuln_http_url_list %}
-                  <li>{{vuln_urls.grouper}}</li>
-                  <span class="mini-heading">Result/Findings</span><br>
-                  {% for vuln in vuln_urls.list %}
-                    {% if vuln.matcher_name %}
-                      {% if not forloop.first %} • {% endif %} {{vuln.matcher_name}}
-                    {% endif %}
-                    {% if vuln.extracted_results %}
-                      {% for res in vuln.extracted_results %}
-                        {% if not forloop.first %} • {% endif %} {{res}}
-                      {% endfor %}
-                    {% endif %}
-                  {% endfor %}
-                {% endfor %}
-              </ul> -->
-              {% if vulnerability.list.0.references.all %}
-                <span class="mini-heading">References</span><br>
+                <span class="mini-heading">Vulnerable URL(s)</span><br>
                 <ul>
-                  {% for ref in vulnerability.list.0.references.all %}
-                  <li>
-                    <span class="text-blue"> {{ref}} </span>
-                  </li>
-                  {% endfor %}
+                    <li class="text-blue"><a href="{{vulnerability.http_url}}" target="_blank">{{vulnerability.http_url}}</a></li>
                 </ul>
-              {% endif %}
-              <br>
-              <br>
-            </div>
+                <!-- {% regroup vulnerability.list by http_url as vuln_http_url_list %} -->
+                <!-- <ul>
+                  {% for vuln_urls in vuln_http_url_list %}
+                    <li>{{vuln_urls.grouper}}</li>
+                    <span class="mini-heading">Result/Findings</span><br>
+                    {% for vuln in vuln_urls.list %}
+                      {% if vuln.matcher_name %}
+                        {% if not forloop.first %} • {% endif %} {{vuln.matcher_name}}
+                      {% endif %}
+                      {% if vuln.extracted_results %}
+                        {% for res in vuln.extracted_results %}
+                          {% if not forloop.first %} • {% endif %} {{res}}
+                        {% endfor %}
+                      {% endif %}
+                    {% endfor %}
+                  {% endfor %}
+                </ul> -->
+                {% if vulnerability.references.all %}
+                  <span class="mini-heading">References</span><br>
+                  <ul>
+                    {% for ref in vulnerability.references.all %}
+                    <li>
+                      <span class="text-blue"><a href="{{ref}}" target="_blank">{{ref}}</a></span>
+                    </li>
+                    {% endfor %}
+                  </ul>
+                {% endif %}
+                <br>
+                <br>
+              </div>
+            {% endfor %}
           {% endfor %}
         </article>
       {% endif %}

--- a/web/templates/report/template.html
+++ b/web/templates/report/template.html
@@ -1001,7 +1001,7 @@
                 <br>
                 <span class="mini-heading">Vulnerable URL(s)</span><br>
                 <ul>
-                    <li class="text-blue"><a href="{{vulnerability.http_url}}" target="_blank">{{vulnerability.http_url}}</a></li>
+                    <li class="text-blue"><a href="{{vulnerability.http_url}}" target="_blank" rel="noopener noreferrer">{{vulnerability.http_url}}</a></li>
                 </ul>
                 <!-- {% regroup vulnerability.list by http_url as vuln_http_url_list %} -->
                 <!-- <ul>
@@ -1025,7 +1025,7 @@
                   <ul>
                     {% for ref in vulnerability.references.all %}
                     <li>
-                      <span class="text-blue"><a href="{{ref}}" target="_blank">{{ref}}</a></span>
+                      <span class="text-blue"><a href="{{ref}}" target="_blank" rel="noopener noreferrer">{{ref}}</a></span>
                     </li>
                     {% endfor %}
                   </ul>

--- a/web/templates/report/template.html
+++ b/web/templates/report/template.html
@@ -514,7 +514,7 @@
           <p class="bg-critical">Vulnerabilities
             <br>
             <span class="inside-box-counter">
-              {{scan_object.get_vulnerability_count}}
+              {{all_vulnerabilities_count}}
             </span>
           </p>
         </section>
@@ -563,7 +563,11 @@
             <p class="bg-info">Info
               <br>
               <span class="inside-box-counter">
-                {{scan_object.get_info_vulnerability_count}}
+                {% if is_ignore_info_vuln %}
+                  0
+                {% else %}
+                  {{scan_object.get_info_vulnerability_count}}
+                {% endif %}
               </span>
             </p>
           </section>
@@ -834,11 +838,11 @@
                 </td>
               </tr>
             {% endif %}
-            {% if subdomain.get_vulnerabilities %}
+            {% if subdomain.get_vulnerabilities_without_info %}
               <tr>
                 <td colspan="3" class="cell table-border">
                   Vulnerabilities
-                  {% regroup subdomain.get_vulnerabilities by name as vuln_list %}
+                  {% regroup subdomain.get_vulnerabilities_without_info by name as vuln_list %}
                   <ul>
                     {% for vulnerability in vuln_list %}
                       <li>
@@ -864,7 +868,7 @@
           {{scan_object.get_critical_vulnerability_count}} of them were Critical,
           {{scan_object.get_high_vulnerability_count}} of them were High Severity,
           {{scan_object.get_medium_vulnerability_count}} of them were Medium severity,
-          {{scan_object.get_low_vulnerability_count}} of them were Low severity, and
+          {% if is_ignore_info_vuln %}0{% else %}{{scan_object.get_info_vulnerability_count}}{% endif %} of them were Low severity, and
           {{scan_object.get_info_vulnerability_count}} of them were Informational.
           {{scan_object.get_unknown_vulnerability_count}} of them were Unknown Severity.
         </p>
@@ -906,7 +910,11 @@
             <p class="bg-info">Info
               <br>
               <span class="inside-box-counter">
-                {{scan_object.get_info_vulnerability_count}}
+                {% if is_ignore_info_vuln %}
+                  0
+                {% else %}
+                  {{scan_object.get_info_vulnerability_count}}
+                {% endif %}
               </span>
             </p>
           </section>


### PR DESCRIPTION
When **Ignore Informational Vulnerabilities** is checked there are still info vulns datas.

I've reworked the queries that display vulnerabilities to prevent info vulns to display in the :
- **Quick summary** Info blue box
- **Reconnaissance Findings**
- **Vulnerabilities Discovered** Info blue box

I've also fixed the **Vulnerabilities Discovered** listing by doing a correct loop through regrouped values because values withe the same path but not the same severity does not display well

Tested and working on current master branch