### PR TITLE
Update Dockerfile to fix silicon incompatability

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM ubuntu:22.04
+FROM --platform=linux/amd64 ubuntu:22.04
 
 # Labels and Credits
 LABEL \


### PR DESCRIPTION
The installation method doesnt work on devices that arent amd64 as docker will choose a container architecture based on its host system architecture by default. this leads to compatability issues with arm systems and M1 macOS. This little change in the Dockerfile makes Docker emulate amd64 architecture and this way it works.

Tested on: ARM64 macOS, Arch Amd64