### PR TITLE
Feat/issue 492 add orgs when adding targets

### DIFF
--- a/web/api/views.py
+++ b/web/api/views.py
@@ -547,6 +547,7 @@ class AddTarget(APIView):
 		h1_team_handle = data.get('h1_team_handle')
 		description = data.get('description')
 		domain_name = data.get('domain_name')
+		organization_name = data.get('organization')
 		slug = data.get('slug')
 
 		# Validate domain name
@@ -563,6 +564,20 @@ class AddTarget(APIView):
 		if not domain.insert_date:
 			domain.insert_date = timezone.now()
 		domain.save()
+
+		# Create org object in DB
+		if organization_name:
+			organization_obj = None
+			organization_query = Organization.objects.filter(name=organization_name)
+			if organization_query.exists():
+				organization_obj = organization_query[0]
+			else:
+				organization_obj = Organization.objects.create(
+					name=organization_name,
+					project=project,
+					insert_date=timezone.now())
+			organization_obj.domains.add(domain)
+
 		return Response({
 			'status': True,
 			'message': 'Domain successfully added as target !',

--- a/web/static/custom/custom.js
+++ b/web/static/custom/custom.js
@@ -1854,10 +1854,15 @@ function show_quick_add_target_modal() {
 			<label for="target_description_modal" class="form-label">Description (Optional)</label>
 			<input class="form-control" type="text" id="target_description_modal" required="" placeholder="Target Description">
 		</div>
-
+		
 		<div class="mb-3">
 			<label for="h1_handle_modal" class="form-label">Hackerone Target Team Handle (Optional)</label>
 			<input class="form-control" type="text" id="h1_handle_modal" placeholder="hackerone.com/team_handle, Only enter team_handle after /">
+		</div>
+
+		<div class="mb-3">
+			<label for="target_organization_modal" class="form-label">Target Organization (Optional)</label>
+			<input class="form-control" type="text" id="target_organization_modal" placeholder="Target Org">
 		</div>
 
 		<div class="mb-3 text-center">
@@ -1874,11 +1879,12 @@ function add_quick_target() {
 	var domain_name = $('#target_name_modal').val();
 	var description = $('#target_description_modal').val();
 	var h1_handle = $('#h1_handle_modal').val();
-	add_target(domain_name, h1_handle = h1_handle, description = description);
+	var organization = $('#target_organization_modal').val();
+	add_target(domain_name, h1_handle = h1_handle, description = description, organization = organization);
 }
 
 
-function add_target(domain_name, h1_handle = null, description = null) {
+function add_target(domain_name, h1_handle = null, description = null, organization = null) {
 	var current_slug = getCurrentProjectSlug();
 	// this function will add domain_name as target
 	console.log('Adding new target ' + domain_name)
@@ -1887,6 +1893,7 @@ function add_target(domain_name, h1_handle = null, description = null) {
 		'domain_name': domain_name,
 		'h1_team_handle': h1_handle,
 		'description': description,
+		'organization': organization,
 		'slug': current_slug
 	};
 	swal.queue([{

--- a/web/targetApp/forms.py
+++ b/web/targetApp/forms.py
@@ -33,6 +33,15 @@ class AddTargetForm(forms.Form):
                 "placeholder": "team_handle"
             }
         ))
+    organization_name = forms.CharField(
+        required=False,
+        widget=forms.TextInput(
+            attrs={
+                "class": "form-control form-control-lg",
+                "id": "organizationName",
+                "placeholder": "Organization Name"
+            }
+        ))
 
 class AddOrganizationForm(forms.Form):
     def __init__(self, *args, **kwargs):

--- a/web/targetApp/templates/target/add.html
+++ b/web/targetApp/templates/target/add.html
@@ -155,6 +155,10 @@ Add or Import Targets
                 </label>
                 <input type="text" class="form-control form-control-lg" id="targetH1TeamHandle" placeholder="team_handle" name="targetH1TeamHandle">
               </div>
+              <div class="col-12 mt-3">
+                <label for="targetDescription">Target Organization (Optional)</label>
+                <input type="text" class="form-control form-control-lg" id="targetOrganization" placeholder="Example Org" name="targetOrganization">
+              </div>
             </div>
             <button class="btn btn-primary submit-fn mt-2 float-end" type="submit" id="add-multiple-targets" name="add-multiple-targets" value="submit">Add 0 Target</button>
           </form>

--- a/web/targetApp/views.py
+++ b/web/targetApp/views.py
@@ -52,6 +52,7 @@ def add_target(request, slug):
                 logger.info(f'Adding multiple targets: {bulk_targets}')
                 description = request.POST.get('targetDescription', '')
                 h1_team_handle = request.POST.get('targetH1TeamHandle')
+                organization_name = request.POST.get('targetOrganization')
                 for target in bulk_targets:
                     target = target.rstrip('\n')
                     http_urls = []
@@ -120,6 +121,18 @@ def add_target(request, slug):
                             added_target_count += 1
                             if created:
                                 logger.info(f'Added new domain {domain.name}')
+
+                            if organization_name:
+                                organization = None
+                                if Organization.objects.filter(name=organization_name).exists():
+                                    organization = organization_query[0]
+                                else:
+                                    organization = Organization.objects.create(
+                                        name=organization_name,
+                                        project=project,
+                                        insert_date=timezone.now())
+                                organization.domains.add(domain)
+
 
                     for http_url in http_urls:
                         http_url = sanitize_url(http_url)


### PR DESCRIPTION
Fixes #492.

This PR introduces optional input for adding target to an organization when adding target via:
1) Normal add target form
2) The quick add target modal (and thus the quick add target API)
3) With organizations via normal form and via modal for quick add