### PR TITLE
Fix recursive ffuf launch

### DIFF
--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -10,6 +10,7 @@ import xmltodict
 import yaml
 import tldextract
 import concurrent.futures
+import base64
 
 from datetime import datetime
 from urllib.parse import urlparse
@@ -1670,11 +1671,13 @@ def dir_file_fuzz(self, ctx={}, description=None):
 			results.append(line)
 
 			# Retrieve FFUF output
-			name = line['input'].get('FUZZ')
+			url = line['url']
+			url_fuzzed = urlparse(url)
+			# convert to base64 (need byte string encode & decode)
+			name = base64.b64encode(url_fuzzed.path.encode()).decode()
 			length = line['length']
 			status = line['status']
 			words = line['words']
-			url = line['url']
 			lines = line['lines']
 			content_type = line['content-type']
 			duration = line['duration']

--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -1661,9 +1661,15 @@ def dir_file_fuzz(self, ctx={}, description=None):
 				history_file=self.history_file,
 				scan_id=self.scan_id,
 				activity_id=self.activity_id):
+
+			# Empty line, continue to the next record
 			if not isinstance(line, dict):
 				continue
+
+			# Append line to results
 			results.append(line)
+
+			# Retrieve FFUF output
 			name = line['input'].get('FUZZ')
 			length = line['length']
 			status = line['status']
@@ -1672,38 +1678,57 @@ def dir_file_fuzz(self, ctx={}, description=None):
 			lines = line['lines']
 			content_type = line['content-type']
 			duration = line['duration']
+
+			# If name empty log error and continue
 			if not name:
 				logger.error(f'FUZZ not found for "{url}"')
 				continue
+
+			# Get or create endpoint from URL
 			endpoint, created = save_endpoint(url, crawl=False, ctx=ctx)
+
+			# Continue to next line if endpoint returned is None
+			if endpoint == None:
+				continue
+
+			# Save endpoint data from FFUF output
 			endpoint.http_status = status
 			endpoint.content_length = length
 			endpoint.response_time = duration / 1000000000
-			endpoint.save()
-			if created:
-				urls.append(endpoint.http_url)
-			endpoint.status = status
 			endpoint.content_type = content_type
 			endpoint.content_length = length
+			endpoint.save()
+
+			# Save directory file output from FFUF output
 			dfile, created = DirectoryFile.objects.get_or_create(
 				name=name,
 				length=length,
 				words=words,
 				lines=lines,
 				content_type=content_type,
-				url=url)
-			dfile.http_status = status
-			dfile.save()
-			# if created:
-			# 	logger.warning(f'Found new directory or file {url}')
-			dirscan.directory_files.add(dfile)
-			dirscan.save()
+				url=url,
+				http_status=status)
 
+			# Log newly created file or directory if debug activated
+			if created and DEBUG:
+				logger.warning(f'Found new directory or file {url}')
+
+			# Add file to current dirscan
+			dirscan.directory_files.add(dfile)
+
+			# Add subscan relation to dirscan if exists
 			if self.subscan:
 				dirscan.dir_subscan_ids.add(self.subscan)
 
-			subdomain_name = get_subdomain_from_url(endpoint.http_url)
-			subdomain = Subdomain.objects.get(name=subdomain_name, scan_history=self.scan)
+			# Save dirscan datas
+			dirscan.save()
+
+			# Get subdomain and add dirscan
+			if ctx['subdomain_id'] > 0:
+				subdomain = Subdomain.objects.get(id=ctx['subdomain_id'])
+			else:
+				subdomain_name = get_subdomain_from_url(endpoint.http_url)
+				subdomain = Subdomain.objects.get(name=subdomain_name, scan_history=self.scan)
 			subdomain.directories.add(dirscan)
 			subdomain.save()
 


### PR DESCRIPTION
Fix #1113 

- Removed Recursive loop
- Add a test for endpoints that generate a crash and prevent FFUF from finishing
![image](https://github.com/yogeshojha/rengine/assets/1230954/af2d7be4-cb2f-4d0a-afcf-ad074e661c30)
- Adding comments to be clear on the actions carried out in file fuzzing
- Variable FUZZ does not return full path in recursive mode but only the file fuzzed, isubdir are not displayed, so I replace it with URL Path, now subdir is displayed
![image](https://github.com/yogeshojha/rengine/assets/1230954/01f3b3fc-8659-4ac3-8ff3-021f600f7ce7)

Currently testing
