### PR TITLE
Update auto comment workflow due to deprecation warnings

### DIFF
--- a/.github/workflows/auto-comment.yml
+++ b/.github/workflows/auto-comment.yml
@@ -4,7 +4,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: bubkoo/auto-comment@v1.0.7
+      - uses: bubkoo/auto-comment@v1.1.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           issuesOpened: >


### PR DESCRIPTION
* This will fix deprecation warnings in auto comment
* For github_token and Docker username and password I do not have enough permission But we can try these.

1. **Disable and re-enable the integration**: Go to the repository's settings, navigate to the "Integrations & services" (or similar) section, find the GitHub Actions integration, and disable it. Then, re-enable it again. This can help refresh the integration's access to the repository.

2. **Check repository permissions**: Ensure that the GitHub Actions integration has the necessary permissions to access the repository and perform the required actions. Make sure it has appropriate read and write access.

3. **Review workflow configuration**: Double-check your workflow file to ensure that it references the correct repository name and settings. Confirm that the release package and tag you are trying to access are properly set up in the workflow.

4. V**erify authentication**: Ensure that the GITHUB_TOKEN used in your workflow file is correctly set and has the necessary permissions to access and modify releases.

![image](https://github.com/yogeshojha/rengine/assets/14043035/42ba368e-d9bd-4d6d-b762-25cf6a261613)

**Adding Docker Credentials**: To securely add your Docker username and password to GitHub repository for CI/CD processes:

1. Go to your repository on GitHub.
2. Click on 'Settings' and then 'Secrets'.
3. Choose 'New repository secret'.
4. Add your Docker username and password as two separate secrets. Name them DOCKER_USERNAME and DOCKER_PASSWORD.
5. Use these secrets in your GitHub Actions workflow by referencing them as ${{ secrets.DOCKER_USERNAME }} and ${{ secrets.DOCKER_PASSWORD }}.