### PR TITLE
fixed uninstall script bug, incorrect docker container name

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -11,7 +11,7 @@ if [ "$EUID" -ne 0 ]
 fi
 
 echo "Stopping reNgine"
-docker stop rengine_web_1 rengine_db_1 rengine_celery_1 rengine_celery-beat_1 rengine_redis_1 rengine_tor_1 rengine_proxy_1
+docker stop rengine-web-1 rengine-db-1 rengine-celery-1 rengine-celery-beat-1 rengine-redis-1 rengine-tor-1 rengine-proxy-1
 
 if [[ $REPLY =~ ^[Yy]$ ]]
 then


### PR DESCRIPTION
Fixed a bug that was preventing the uninstall script from doing the task. 

![image](https://github.com/yogeshojha/rengine/assets/149691449/95107b18-c495-4aaa-b5a2-a589aca2d97f)
