### PR TITLE
CI: Code linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: Ruff
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Ruff lint
+        uses: chartboost/ruff-action@v1
+        with:
+          args: check .

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,28 @@
+# Folders to exclude from linting
+exclude = [
+	".github",
+	"certs",
+	"scripts",
+	"env",
+	"venv",
+	"__pycache__"
+]
+
+indent-width = 4
+
+[lint]
+ignore = [
+	"E402", # Import not at top of file
+	"F403", # unable to detect undefined names
+	"F405" # may be undefined, or defined from star imports
+]
+
+[format]
+# Indent with tabs
+indent-style = "tab"
+
+# Use double quotes for strings
+quote-style = "double"
+
+# Automatically detect the appropriate line ending
+line-ending = "auto"


### PR DESCRIPTION
Add Ruff linter for the whole codebase. The pipeline will fail here obviously as the fixes / formatting wasn't applied yet.
That will be done in a different PR.

Closes #1134.