### PR TITLE
Fixed (subdomain_discovery | ERROR | local variable 'use_amass_config' referenced before assignment)

### DIFF
--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -416,6 +416,7 @@ def subdomain_discovery(
 		proxy = get_random_proxy()
 		if tool in default_subdomain_tools:
 			if tool == 'amass-passive':
+				use_amass_config = config.get(USE_AMASS_CONFIG, False)
 				cmd = f'amass enum -passive -d {host} -o {self.results_dir}/subdomains_amass.txt'
 				cmd += ' -config /root/.config/amass.ini' if use_amass_config else ''
 


### PR DESCRIPTION
The code use_amass_config = config.get(USE_AMASS_CONFIG, False) retrieves the value associated with the key USE_AMASS_CONFIG from a configuration dictionary (config). If the key is not found, it defaults to False. The variable use_amass_config is then assigned this value.

Closes: https://github.com/yogeshojha/rengine/issues/1148

