### PR TITLE
Add checks for placeholder in custom tool task

### DIFF
--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -468,14 +468,20 @@ def subdomain_discovery(
 		elif tool in custom_subdomain_tools:
 			tool_query = InstalledExternalTool.objects.filter(name__icontains=tool.lower())
 			if not tool_query.exists():
-				logger.error(f'Missing {{TARGET}} and {{OUTPUT}} placeholders in {tool} configuration. Skipping.')
+				logger.error(f'{tool} configuration does not exists. Skipping.')
 				continue
+			if '{TARGET}' not in cmd:
+				logger.error(f'Missing {{TARGET}} placeholders in {tool} configuration. Skipping.')
+				continue
+			if '{OUTPUT}' not in cmd:
+				logger.error(f'Missing {{OUTPUT}} placeholders in {tool} configuration. Skipping.')
+				continue
+
 			custom_tool = tool_query.first()
 			cmd = custom_tool.subdomain_gathering_command
-			if '{TARGET}' in cmd and '{OUTPUT}' in cmd:
-				cmd = cmd.replace('{TARGET}', host)
-				cmd = cmd.replace('{OUTPUT}', f'{self.results_dir}/subdomains_{tool}.txt')
-				cmd = cmd.replace('{PATH}', custom_tool.github_clone_path) if '{PATH}' in cmd else cmd
+			cmd = cmd.replace('{TARGET}', host)
+			cmd = cmd.replace('{OUTPUT}', f'{self.results_dir}/subdomains_{tool}.txt')
+			cmd = cmd.replace('{PATH}', custom_tool.github_clone_path) if '{PATH}' in cmd else cmd
 		else:
 			logger.warning(
 				f'Subdomain discovery tool "{tool}" is not supported by reNgine. Skipping.')

--- a/web/scanEngine/templates/scanEngine/settings/_items/external_tool_form.html
+++ b/web/scanEngine/templates/scanEngine/settings/_items/external_tool_form.html
@@ -153,11 +153,11 @@
     <div class="">
       <span class="font-16">
         reNgine needs to know how this tool accepts target and output the subdomain results.<br>
-        <strong>Use the below syntax wherever required.</strong>
+        <strong>Use the below syntax wherever required, but remember that <code>{TARGET}</code> and <code>{OUTPUT}</code> <strong>are mandatory placeholders</strong>.</strong>
         <ul>
+          <li><code>{TARGET}</code> (mandatory), Use this for the command-line arg that takes in domain as input target. Example. <code>subfinder -d {TARGET}</code></li>
+          <li><code>{OUTPUT}</code> (mandatory), Use this for the command-line arg that takes the output arg. Example. <code>subfinder -d {TARGET} -o {OUTPUT}</code></li>
           <li><code>{PATH}</code>, Use this if your tool is github cloned. Example. <code>python3 {PATH}/subdomain.py</code></li>
-          <li><code>{TARGET}</code>, Use this for the command-line arg that takes in domain as input target. Example. <code>subfinder -d {TARGET}</code></li>
-          <li><code>{OUTPUT}</code>, Use this for the command-line arg that takes the output arg. Example. <code>subfinder -d {TARGET} -o {OUTPUT}</code></li>
           <li><code>{PROXY}</code>, Use this if your tool supports proxy. Example. <code>tool_name -p {PROXY}</code></li>
         </ul>
         You can use the combinations of the above syntax and also you can use any other command-line argument that your tool supports.


### PR DESCRIPTION
Fix #1010 

**TARGET** and **OUTPUT** are mandatory field but checks in code is not really accurate, so it generates error if one os this two placeholders is omitted

I've improved placeholders check in tasks

I've also added this information in the form page
![image](https://github.com/yogeshojha/rengine/assets/1230954/41262f9d-6bc5-4796-a5ed-911a65795212)
