### PR TITLE
Whatportis - Replace purge by truncate to prevent port import error

### DIFF
--- a/web/celery-entrypoint.sh
+++ b/web/celery-entrypoint.sh
@@ -22,6 +22,9 @@ Pin-Priority: -1
 apt update
 apt install firefox -y
 
+# Temporary fix for whatportis bug - See https://github.com/yogeshojha/rengine/issues/984
+sed -i 's/purge()/truncate()/g' /usr/local/lib/python3.10/dist-packages/whatportis/cli.py
+
 # update whatportis
 yes | whatportis --update
 


### PR DESCRIPTION
Fix #984 

It's temporary until we decide what to do with deprecated whatportis
See discussion on #984 