### PR TITLE
Fix importing CIDR blocks

### DIFF
--- a/web/api/views.py
+++ b/web/api/views.py
@@ -1086,7 +1086,7 @@ class IPToDomain(APIView):
 		try:
 			logger.info(f'Resolving IP address {ip_address} ...')
 			resolved_ips = []
-			for ip in IPv4Network(ip_address):
+			for ip in IPv4Network(ip_address, False):
 				domains = []
 				ips = []
 				try:

--- a/web/api/views.py
+++ b/web/api/views.py
@@ -2,6 +2,7 @@ import logging
 import re
 import socket
 import subprocess
+from ipaddress import IPv4Network
 
 import requests
 import validators
@@ -1084,20 +1085,22 @@ class IPToDomain(APIView):
 			})
 		try:
 			logger.info(f'Resolving IP address {ip_address} ...')
-			domain, domains, ips = socket.gethostbyaddr(ip_address)
+			resolved_ips = []
+			for ip in IPv4Network(ip_address):
+				domains = []
+				ips = []
+				try:
+					(domain, domains, ips) = socket.gethostbyaddr(str(ip))
+				except socket.herror:
+					logger.info(f'No PTR record for {ip_address}')
+					domain = str(ip)
+				if domain not in domains:
+					domains.append(domain)
+				resolved_ips.append({'ip': str(ip),'domain': domain, 'domains': domains, 'ips': ips})
 			response = {
 				'status': True,
-				'ip_address': ip_address,
-				'domains': domains or [domain],
-				'resolves_to': domain
-			}
-		except socket.herror: # ip does not have a PTR record
-			logger.info(f'No PTR record for {ip_address}')
-			response = {
-				'status': True,
-				'ip_address': ip_address,
-				'domains': [ip_address],
-				'resolves_to': ip_address
+				'orig': ip_address,
+				'ip_address': resolved_ips,
 			}
 		except Exception as e:
 			logger.exception(e)

--- a/web/targetApp/templates/target/add.html
+++ b/web/targetApp/templates/target/add.html
@@ -257,18 +257,22 @@ Add or Import Targets
             if (json_data['status']) {
               // #resolved_domains_div
               $("#all_domains_checkbox").show();
-              $('#resolved_domains_div').append(`<b class='text-info'>${json_data['domains'].length} domains associated with IP Address ${ip_address.value}</b></br>`);
-              $('#resolved_domains_div').append(`<b>Please select the domains to import.</b>`);
-              $('#resolved_domains_div').append(`<div id='domains_checkbox' class='mt-2 row'></div>`);
-              for (var domain in json_data['domains']) {
-                $('#domains_checkbox').append(`
-                <div class="col-xl-2 col-md-4 col-sm-6 col-12">
-                  <div class="form-check">
-                    <input type="checkbox" class="form-check-input resolved_ip_domains" name="resolved_ip_domains" id="${json_data['domains'][domain]}" value="${json_data['domains'][domain]}">
-                    <label class="form-check-label" for="${json_data['domains'][domain]}">${json_data['domains'][domain]}</label>
-                  </div>
-                </div>`
-                );
+              if(Array.isArray(json_data['ip_address'])) {
+                $('#resolved_domains_div').append(`<b class='text-info'>${json_data['ip_address'].length} domains associated with IP Address ${json_data['orig']}</b></br>`);
+                $('#resolved_domains_div').append(`<b>Please select the domains to import.</b>`);
+                $('#resolved_domains_div').append(`<div id='domains_checkbox' class='mt-2 row'></div>`);
+                json_data['ip_address'].forEach((ip_info, index, array) => {
+                  for (var domain in ip_info['domains']) {
+                    $('#domains_checkbox').append(`
+                    <div class="col-xl-2 col-md-4 col-sm-6 col-12">
+                      <div class="form-check">
+                        <input type="checkbox" class="form-check-input resolved_ip_domains" name="resolved_ip_domains" id="${ip_info['domains'][domain]}" value="${ip_info['domains'][domain]}">
+                        <label class="form-check-label" for="${ip_info['domains'][domain]}">${ip_info['domains'][domain]}</label>
+                      </div>
+                    </div>`
+                    );
+                  }
+                })
               }
               swal.close();
               // resolved_ip_domains if any is checked, then only enable add button

--- a/web/targetApp/views.py
+++ b/web/targetApp/views.py
@@ -92,8 +92,8 @@ def add_target(request, slug):
                         domains.append(target)
 
                     elif is_range:
-                        ips = get_ips_from_cidr_range(target)
-                        for ip_address in ips:
+                        _ips = get_ips_from_cidr_range(target)
+                        for ip_address in _ips:
                             ips.append(ip_address)
                             domains.append(ip_address)
                     else:

--- a/web/targetApp/views.py
+++ b/web/targetApp/views.py
@@ -583,6 +583,6 @@ def get_ip_info(ip_address):
 
 def get_ips_from_cidr_range(target):
     try:
-        return [str(ip) for ip in ipaddress.IPv4Network(target)]
+        return [str(ip) for ip in ipaddress.IPv4Network(target, False)]
     except Exception as e:
         logger.error(f'{target} is not a valid CIDR range. Skipping.')


### PR DESCRIPTION
Importing CIDR blocks as targets was broken in a few different ways.

1. When adding CIDR targets via the multiple targets tab, there was a variable name collision that resulted in an infinite loop and memory leak being created which would quickly exhaust all memory on the system until the web process was killed. The name of the variable was changed from "ips" to "_ips" to correct this.
2. When adding a CIDR block via the resolve IP tab, the CIDR block was passed directly to gethostbyaddr(), which does not accept CIDR blocks, resulting in an error. This PR fixes that issue by expanding the CIDR block and passing each IP to gethostbyaddr(), and returning the domains for any which were resolved. This required a small API change to the IPToDomain API to send back a list of objects for each IP in the CIDR block and any resulting found domains for each IP.
3. When adding any domains found by resolving an IP or CIDR block, those domains were not added to the database of targets, resulting in an error stating "Oops! Could not import any targets, either targets already exists or is not a valid target." This PR adds the selected target domains to the database and updates the added_target_count. It also adds any IP targets to the IpAddress model, similar to when IPs are added to via the multiple targets tab.

Thanks to my employer, EasyPost, for allowing me the time to resolve these issues.