### PR TITLE
Fix uninitialised variable cmd in custom_subdomain_tools

### DIFF
--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -472,6 +472,8 @@ def subdomain_discovery(
 			if not tool_query.exists():
 				logger.error(f'{tool} configuration does not exists. Skipping.')
 				continue
+			custom_tool = tool_query.first()
+			cmd = custom_tool.subdomain_gathering_command
 			if '{TARGET}' not in cmd:
 				logger.error(f'Missing {{TARGET}} placeholders in {tool} configuration. Skipping.')
 				continue
@@ -479,8 +481,7 @@ def subdomain_discovery(
 				logger.error(f'Missing {{OUTPUT}} placeholders in {tool} configuration. Skipping.')
 				continue
 
-			custom_tool = tool_query.first()
-			cmd = custom_tool.subdomain_gathering_command
+			
 			cmd = cmd.replace('{TARGET}', host)
 			cmd = cmd.replace('{OUTPUT}', f'{self.results_dir}/subdomains_{tool}.txt')
 			cmd = cmd.replace('{PATH}', custom_tool.github_clone_path) if '{PATH}' in cmd else cmd


### PR DESCRIPTION
custom tool for subdomain scanning is failing as it is failing to find {TARGET} in the run command even if it is properly defined in the web portal.

checking the logs showed that line

```Python
if '{TARGET}' not in cmd:
```

failed as cmd was None.

cmd is used here to check required values but it is defined after this check.

```python
			if '{TARGET}' not in cmd:
				logger.error(f'Missing {{TARGET}} placeholders in {tool} configuration. Skipping.')
				continue
			if '{OUTPUT}' not in cmd:
				logger.error(f'Missing {{OUTPUT}} placeholders in {tool} configuration. Skipping.')
				continue

			custom_tool = tool_query.first()
			cmd = custom_tool.subdomain_gathering_command
			cmd = cmd.replace('{TARGET}', host)
```
Thus, fixing the cmd variable initialisation.