### PR TITLE
fix: add missing os library to check celery broker env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ docs/_build/
 # pyenv
 .python-version
 
+.idea/
 **/.DS_Store
 staticfiles/
 
@@ -62,3 +63,7 @@ get-docker.sh
 
 # Environment variables
 .env
+
+# Python environment
+env/
+venv/

--- a/web/reNgine/celery_custom_task.py
+++ b/web/reNgine/celery_custom_task.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 from celery import Task
 from celery.utils.log import get_task_logger


### PR DESCRIPTION
- add python environment stuff and editor miscellaneous file to `.gitignore`
- add missing `os` library to `web/reNgine/celery_custom_task.py` to correctly check for `CELERY_BROKER` env var

this will start working afterward:
```python3
if 'CELERY_BROKER' in os.environ:
	cache = Redis.from_url(os.environ['CELERY_BROKER'])
```