### PR TITLE
Dockerfile cleanup: reduce image size 3x

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,13 +12,11 @@ ENV DEBIAN_FRONTEND="noninteractive" \
     DATABASE="postgres"
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
-ENV GOROOT="/usr/local/go"
 ENV GOPATH=$HOME/go
-ENV PATH="${PATH}:${GOROOT}/bin:${GOPATH}/bin"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 # Install Python
-RUN apt update -y && \
-    apt update -y && \
+RUN apt update && \
     apt install -y \
     python3.10 \
     python3-dev \
@@ -48,16 +46,15 @@ RUN apt install -y  --no-install-recommends \
 RUN add-apt-repository ppa:mozillateam/ppa
 
 # Download and install go 1.20
-RUN wget https://golang.org/dl/go1.21.4.linux-amd64.tar.gz
-RUN tar -xvf go1.21.4.linux-amd64.tar.gz
-RUN rm go1.21.4.linux-amd64.tar.gz
-RUN mv go /usr/local
+RUN wget https://golang.org/dl/go1.21.4.linux-amd64.tar.gz && \
+    tar -xvf go1.21.4.linux-amd64.tar.gz go/bin/go --strip-components=2 && \
+    rm go1.21.4.linux-amd64.tar.gz && \
+    mv go /usr/local/bin/
 
 # Download geckodriver
-RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.32.0/geckodriver-v0.32.0-linux64.tar.gz
-RUN tar -xvf geckodriver-v0.32.0-linux64.tar.gz
-RUN rm geckodriver-v0.32.0-linux64.tar.gz
-RUN mv geckodriver /usr/bin
+RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.32.0/geckodriver-v0.32.0-linux64.tar.gz && \
+    tar -xvf geckodriver-v0.32.0-linux64.tar.gz -C /usr/bin/ && \
+    rm geckodriver-v0.32.0-linux64.tar.gz
 
 # Make directory for app
 WORKDIR /usr/src/app

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,8 +12,9 @@ ENV DEBIAN_FRONTEND="noninteractive" \
     DATABASE="postgres"
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
+ENV GOROOT="/usr/local/go"
 ENV GOPATH=$HOME/go
-ENV PATH="${PATH}:${GOPATH}/bin"
+ENV PATH="${PATH}:${GOROOT}/bin:${GOPATH}/bin"
 
 # Install Python
 RUN apt update && \
@@ -47,9 +48,8 @@ RUN add-apt-repository ppa:mozillateam/ppa
 
 # Download and install go 1.20
 RUN wget https://golang.org/dl/go1.21.4.linux-amd64.tar.gz && \
-    tar -xvf go1.21.4.linux-amd64.tar.gz go/bin/go --strip-components=2 && \
-    rm go1.21.4.linux-amd64.tar.gz && \
-    mv go /usr/local/bin/
+    tar -xvf go1.21.4.linux-amd64.tar.gz -C /usr/local/ && \
+    rm go1.21.4.linux-amd64.tar.gz
 
 # Download geckodriver
 RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.32.0/geckodriver-v0.32.0-linux64.tar.gz && \
@@ -64,44 +64,37 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
 # Download Go packages
-RUN go install -v github.com/jaeles-project/gospider@latest
-RUN go install -v github.com/tomnomnom/gf@latest
-RUN go install -v github.com/tomnomnom/unfurl@latest
-RUN go install -v github.com/tomnomnom/waybackurls@latest
-RUN go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest
-RUN go install -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest
-RUN go install -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest
-RUN go install -v github.com/projectdiscovery/naabu/v2/cmd/naabu@latest
-RUN go install -v github.com/hakluke/hakrawler@latest
-RUN go install -v github.com/lc/gau/v2/cmd/gau@latest
-RUN go install -v github.com/jaeles-project/gospider@latest
-RUN go install -v github.com/owasp-amass/amass/v3/...@latest
-RUN go install -v github.com/ffuf/ffuf@latest
-RUN go install -v github.com/projectdiscovery/tlsx/cmd/tlsx@latest
-RUN go install -v github.com/hahwul/dalfox/v2@latest
-RUN go install -v github.com/projectdiscovery/katana/cmd/katana@latest
-RUN go install -v github.com/dwisiswant0/crlfuzz/cmd/crlfuzz@latest
-RUN go install -v github.com/sa7mon/s3scanner@latest
+RUN printf "\
+    github.com/jaeles-project/gospider@latest\n\
+    github.com/tomnomnom/gf@latest\n\
+    github.com/tomnomnom/unfurl@latest\n\
+    github.com/tomnomnom/waybackurls@latest\n\
+    github.com/projectdiscovery/httpx/cmd/httpx@latest\n\
+    github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest\n\
+    github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest\n\
+    github.com/projectdiscovery/naabu/v2/cmd/naabu@latest\n\
+    github.com/hakluke/hakrawler@latest\n\
+    github.com/lc/gau/v2/cmd/gau@latest\n\
+    github.com/jaeles-project/gospider@latest\n\
+    github.com/owasp-amass/amass/v3/...@latest\n\
+    github.com/ffuf/ffuf@latest\n\
+    github.com/projectdiscovery/tlsx/cmd/tlsx@latest\n\
+    github.com/hahwul/dalfox/v2@latest\n\
+    github.com/projectdiscovery/katana/cmd/katana@latest\n\
+    github.com/dwisiswant0/crlfuzz/cmd/crlfuzz@latest\n\
+    github.com/sa7mon/s3scanner@latest\n" | \
+    xargs -L1 go install -v && \
+    rm -rf /go/pkg/*
 
 # Update Nuclei and Nuclei-Templates
-RUN nuclei -update
 RUN nuclei -update-templates
-
-# Update project discovery tools
-RUN httpx -up
-RUN naabu -up
-RUN subfinder -up
-RUN tlsx -up
-RUN katana -up
 
 # Copy requirements
 COPY ./requirements.txt /tmp/requirements.txt
 RUN pip3 install --upgrade setuptools pip && \
     pip3 install -r /tmp/requirements.txt
 
-
 # install eyewitness
-
 RUN python3 -m pip install fuzzywuzzy \
     selenium==4.9.1 \
     python-Levenshtein \
@@ -110,6 +103,3 @@ RUN python3 -m pip install fuzzywuzzy \
 
 # Copy source code
 COPY . /usr/src/app/
-
-# httpx seems to have issue, use alias instead!!!
-RUN echo 'alias httpx="/go/bin/httpx"' >> ~/.bashrc

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -24,7 +24,7 @@ RUN apt update && \
     python3-pip
 
 # Install essential packages
-RUN apt install -y  --no-install-recommends \
+RUN apt install -y --no-install-recommends \
     build-essential \
     cmake \
     geoip-bin \
@@ -64,6 +64,7 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
 # Download Go packages
+ENV GO111MODULE=on 
 RUN printf "\
     github.com/jaeles-project/gospider@latest\n\
     github.com/tomnomnom/gf@latest\n\
@@ -83,8 +84,8 @@ RUN printf "\
     github.com/projectdiscovery/katana/cmd/katana@latest\n\
     github.com/dwisiswant0/crlfuzz/cmd/crlfuzz@latest\n\
     github.com/sa7mon/s3scanner@latest\n" | \
-    xargs -L1 go install -v && \
-    rm -rf /go/pkg/*
+    xargs -L1 go install -ldflags="-s -w" -v && \
+    rm -rf /go/pkg/* && rm -rf /root/.cache/go-build
 
 # Update Nuclei and Nuclei-Templates
 RUN nuclei -update-templates
@@ -92,10 +93,10 @@ RUN nuclei -update-templates
 # Copy requirements
 COPY ./requirements.txt /tmp/requirements.txt
 RUN pip3 install --upgrade setuptools pip && \
-    pip3 install -r /tmp/requirements.txt
+    pip3 install -r /tmp/requirements.txt --no-cache-dir
 
 # install eyewitness
-RUN python3 -m pip install fuzzywuzzy \
+RUN python3 -m pip install --no-cache-dir fuzzywuzzy \
     selenium==4.9.1 \
     python-Levenshtein \
     pyvirtualdisplay \


### PR DESCRIPTION
# Background

The Docker image produced by the `master` branch currently is large: `5.91 GB`. Through some Docker optimizations this size can be reduced to 1/3 of that without losing any functionality.

# Optimizations

### 1. Baseline

```sh
$ docker images
REPOSITORY                                         TAG                  IMAGE ID       CREATED         SIZE
docker.pkg.github.com/yogeshojha/rengine/rengine   latest               41abe57a3889   9 minutes ago   5.91GB
```

### 2. Combine install layers ( -290 MB )

```diff
-RUN wget https://golang.org/dl/go1.21.4.linux-amd64.tar.gz
-RUN tar -xvf go1.21.4.linux-amd64.tar.gz
-RUN rm go1.21.4.linux-amd64.tar.gz
-RUN mv go /usr/local
+RUN wget https://golang.org/dl/go1.21.4.linux-amd64.tar.gz && \
+    tar -xvf go1.21.4.linux-amd64.tar.gz go/bin/go --strip-components=2 && \
+    rm go1.21.4.linux-amd64.tar.gz && \
+    mv go /usr/local/bin/
 
 # Download geckodriver
-RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.32.0/geckodriver-v0.32.0-linux64.tar.gz
-RUN tar -xvf geckodriver-v0.32.0-linux64.tar.gz
-RUN rm geckodriver-v0.32.0-linux64.tar.gz
-RUN mv geckodriver /usr/bin
+RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.32.0/geckodriver-v0.32.0-linux64.tar.gz && \
+    tar -xvf geckodriver-v0.32.0-linux64.tar.gz -C /usr/bin/ && \
+    rm geckodriver-v0.32.0-linux64.tar.gz
```

Each `RUN` instruction in a Dockerfile will result in a new image layer so if you add files, then delete them on separate RUN lines, you don't free up any space with the deletion. Instead, add and delete the files in the same `RUN` instruction. More info about this is in the Docker docs [here](https://docs.docker.com/storage/storagedriver/#images-and-layers). The commands are split up into multiple lines for better readability.

```sh
$ docker images
REPOSITORY   TAG      IMAGE ID       CREATED          SIZE
rengine      latest   fca7bccdbf57   26 seconds ago   5.62GB
```

### 3. Don't cache pip packages ( -80 MB)

```diff
-    pip3 install -r /tmp/requirements.txt
+    pip3 install -r /tmp/requirements.txt --no-cache-dir
```

When `pip` installs Python packages, it caches install data locally to speed up future `pip install` calls. We can clear this cache.

```sh
$ docker images
REPOSITORY   TAG      IMAGE ID       CREATED              SIZE
rengine      latest   82bbc887dabe   About a minute ago   5.54GB
```

### 4. Delete go module cache ( -2 GB)

When `go install` calls are made, go caches all the module dependencies in `/go/pkg/mod`. We can clear this cache and save significant space. 

```sh
root@9c870efaeab3:/usr/src/app# du -sh /go/pkg/*
2.0G    /go/pkg/mod
20K     /go/pkg/sumdb
```

Similar to the optimization in section 2, we need to install the modules and clear the cache in the same `RUN` instruction. To do this, we pipe `printf` into `xargs` to call `go install` on each module.

```diff
-RUN go install -v github.com/jaeles-project/gospider@latest
-RUN go install -v github.com/tomnomnom/gf@latest
...
-RUN go install -v github.com/dwisiswant0/crlfuzz/cmd/crlfuzz@latest
-RUN go install -v github.com/sa7mon/s3scanner@latest
+RUN printf "\
+    github.com/jaeles-project/gospider@latest\n\
+    github.com/tomnomnom/gf@latest\n\
...
+    github.com/dwisiswant0/crlfuzz/cmd/crlfuzz@latest\n\
+    github.com/sa7mon/s3scanner@latest\n" | \
+    xargs -L1 go install -v && \
+    rm -rf /go/pkg/*
```

```sh
$ docker images
REPOSITORY   TAG             IMAGE ID       CREATED          SIZE
rengine      latest          4d9dffd6e952   16 minutes ago   3.68GB
```

### 5. Omit go debug symbols and remove build cache ( -1.9 GB)

```diff
-    xargs -L1 go install -v && \
-    rm -rf /go/pkg/*
+    xargs -L1 go install -ldflags="-s -w" -v && \
+    rm -rf /go/pkg/* && rm -rf /root/.cache/go-build
```

When `go install` is called it's doing a `go build` on the source code it pulls down. We can squeeze an extra bit of space if we use the build flags to omit debug symbols. Go docs [here](https://pkg.go.dev/cmd/link#hdr-Command_Line).
Additionally, go caches build data in `~/.cache/go-build` and in this case it's a significant amount of data - almost 2GB.

```sh
$ docker images
REPOSITORY   TAG             IMAGE ID       CREATED          SIZE
rengine      latest          1c239a350799   30 seconds ago   1.77GB
```

# Other Changes

* Removed extra `apt update`
* Removed ProjectDiscovery `-up` calls. We just installed them 3 lines earlier in the Dockerfile - we know they are up-to-date.
* Removed `httpx` alias. It works just fine without the alias.