### PR TITLE
[FIX] security: OS Command Injection vulnerability (x2) #1219

### DIFF
--- a/web/api/views.py
+++ b/web/api/views.py
@@ -1091,7 +1091,6 @@ class CMSDetector(APIView):
 			match = re.search(path_regex, output)
 			if match:
 				cms_json_path = match.group(1)
-				print(cms_json_path)
 				if os.path.isfile(cms_json_path):
 					cms_file_content = json.loads(open(cms_json_path, 'r').read())
 					if not cms_file_content.get('cms_id'):

--- a/web/api/views.py
+++ b/web/api/views.py
@@ -1086,8 +1086,6 @@ class CMSDetector(APIView):
 
 			if port:
 				find_dir += '_{}'.format(port)
-			# cms_dir_path = '/usr/src/github/CMSeeK/Result/{}'.format(find_dir)
-			# cms_json_path = cms_dir_path + '/cms.json'
 			# look for result path in output
 			path_regex = r"Result: (\/usr\/src[^\"\s]*)"
 			match = re.search(path_regex, output)
@@ -1103,6 +1101,7 @@ class CMSDetector(APIView):
 					response['status'] = True
 					try:
 						# remove results
+						cms_dir_path = os.path.dirname(cms_json_path)
 						shutil.rmtree(cms_dir_path)
 					except Exception as e:
 						logger.error(e)

--- a/web/reNgine/common_func.py
+++ b/web/reNgine/common_func.py
@@ -12,6 +12,7 @@ import redis
 import requests
 import tldextract
 import xmltodict
+import subprocess
 
 from bs4 import BeautifulSoup
 from urllib.parse import urlparse
@@ -510,8 +511,8 @@ def get_cms_details(url):
 	"""
 	# this function will fetch cms details using cms_detector
 	response = {}
-	cms_detector_command = f'python3 /usr/src/github/CMSeeK/cmseek.py --random-agent --batch --follow-redirect -u {url}'
-	os.system(cms_detector_command)
+	cms_detector_command = ['python3', '/usr/src/github/CMSeeK/cmseek.py', '--random-agent', '--batch', '--follow-redirect', '-u', f'{url}']
+	subprocess.run(cms_detector_command)
 
 	response['status'] = False
 	response['message'] = 'Could not detect CMS!'

--- a/web/reNgine/common_func.py
+++ b/web/reNgine/common_func.py
@@ -511,7 +511,7 @@ def get_cms_details(url):
 	"""
 	# this function will fetch cms details using cms_detector
 	response = {}
-	cms_detector_command = ['python3', '/usr/src/github/CMSeeK/cmseek.py', '--random-agent', '--batch', '--follow-redirect', '-u', f'{url}']
+	cms_detector_command = ['python3', '/usr/src/github/CMSeeK/cmseek.py', '--random-agent', '--batch', '--follow-redirect', '-u', url]
 	subprocess.run(cms_detector_command)
 
 	response['status'] = False

--- a/web/reNgine/common_func.py
+++ b/web/reNgine/common_func.py
@@ -4,7 +4,6 @@ import pickle
 import random
 import shutil
 import traceback
-import uuid
 from time import sleep
 
 import humanize
@@ -12,7 +11,6 @@ import redis
 import requests
 import tldextract
 import xmltodict
-import subprocess
 
 from bs4 import BeautifulSoup
 from urllib.parse import urlparse
@@ -27,6 +25,7 @@ from scanEngine.models import *
 from dashboard.models import *
 from startScan.models import *
 from targetApp.models import *
+
 
 logger = get_task_logger(__name__)
 DISCORD_WEBHOOKS_CACHE = redis.Redis.from_url(CELERY_BROKER_URL)
@@ -499,53 +498,13 @@ def get_random_proxy():
 	# os.environ['HTTPS_PROXY'] = proxy_name
 	return proxy_name
 
-
-def get_cms_details(url):
-	"""Get CMS details using cmseek.py.
-
-	Args:
-		url (str): HTTP URL.
-
-	Returns:
-		dict: Response.
-	"""
-	# this function will fetch cms details using cms_detector
-	response = {}
-	cms_detector_command = ['python3', '/usr/src/github/CMSeeK/cmseek.py', '--random-agent', '--batch', '--follow-redirect', '-u', url]
-	subprocess.run(cms_detector_command)
-
-	response['status'] = False
-	response['message'] = 'Could not detect CMS!'
-
-	parsed_url = urlparse(url)
-
-	domain_name = parsed_url.hostname
-	port = parsed_url.port
-
-	find_dir = domain_name
-
-	if port:
-		find_dir += '_{}'.format(port)
-
-	# subdomain may also have port number, and is stored in dir as _port
-
-	cms_dir_path =  '/usr/src/github/CMSeeK/Result/{}'.format(find_dir)
-	cms_json_path =  cms_dir_path + '/cms.json'
-
-	if os.path.isfile(cms_json_path):
-		cms_file_content = json.loads(open(cms_json_path, 'r').read())
-		if not cms_file_content.get('cms_id'):
-			return response
-		response = {}
-		response = cms_file_content
-		response['status'] = True
-		# remove cms dir path
-		try:
-			shutil.rmtree(cms_dir_path)
-		except Exception as e:
-			print(e)
-
-	return response
+def remove_ansi_escape_sequences(text):
+	# Regular expression to match ANSI escape sequences
+	ansi_escape_pattern = r'\x1b\[.*?m'
+	
+	# Use re.sub() to replace the ANSI escape sequences with an empty string
+	plain_text = re.sub(ansi_escape_pattern, '', text)
+	return plain_text
 
 
 #--------------------#

--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -4090,7 +4090,15 @@ def remove_duplicate_endpoints(
 				logger.warning(msg)
 
 @app.task(name='run_command', bind=False, queue='run_command_queue')
-def run_command(cmd, cwd=None, shell=False, history_file=None, scan_id=None, activity_id=None):
+def run_command(
+		cmd, 
+		cwd=None, 
+		shell=False, 
+		history_file=None, 
+		scan_id=None, 
+		activity_id=None,
+		remove_ansi_sequence=False
+	):
 	"""Run a given command using subprocess module.
 
 	Args:
@@ -4099,7 +4107,7 @@ def run_command(cmd, cwd=None, shell=False, history_file=None, scan_id=None, act
 		echo (bool): Log command.
 		shell (bool): Run within separate shell if True.
 		history_file (str): Write command + output to history file.
-
+		remove_ansi_sequence (bool): Used to remove ANSI escape sequences from output such as color coding
 	Returns:
 		tuple: Tuple with return_code, output.
 	"""
@@ -4138,6 +4146,8 @@ def run_command(cmd, cwd=None, shell=False, history_file=None, scan_id=None, act
 			mode = 'w'
 		with open(history_file, mode) as f:
 			f.write(f'\n{cmd}\n{return_code}\n{output}\n------------------\n')
+	if remove_ansi_sequence:
+		output = remove_ansi_escape_sequences(output)
 	return return_code, output
 
 


### PR DESCRIPTION
This code is resistant to command injection because it uses the `subprocess.run()` function with a list of arguments instead of a single-string command.

When you pass a list of arguments to a subprocess.run(), Python will not invoke a shell to execute the command. This means that shell metacharacters such as `;, &&, ||` etc., which could be used to inject additional commands, are treated as literal characters and not interpreted by the shell.

In this case, the URL variable is passed as a separate argument to the command, so even if it contains shell metacharacters, they will not be interpreted as such. This makes the command resistant to command injection attacks.

I have re-tested using the POC and it did not spawn the shell. However, I'd suggest performing a little more extensive test. Let me know if you find anything.