### PR TITLE
use django-env

### DIFF
--- a/web/reNgine/settings.py
+++ b/web/reNgine/settings.py
@@ -1,3 +1,7 @@
+import environ
+
+env = environ.FileAwareEnv()
+
 import mimetypes
 import os
 
@@ -11,39 +15,43 @@ mimetypes.add_type("text/css", ".css", True)
 #       RENGINE CONFIGURATIONS
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Take environment variables from .env file
+environ.Env.read_env(os.path.join(BASE_DIR, os.pardir, '.env'))
+
 # Root env vars
-RENGINE_HOME = os.environ.get('RENGINE_HOME', '/usr/src/app')
-RENGINE_RESULTS = os.environ.get('RENGINE_RESULTS', f'{RENGINE_HOME}/scan_results')
-RENGINE_CACHE_ENABLED = bool(int(os.environ.get('RENGINE_CACHE_ENABLED', '0')))
-RENGINE_RECORD_ENABLED = bool(int(os.environ.get('RENGINE_RECORD_ENABLED', '1')))
-RENGINE_RAISE_ON_ERROR = bool(int(os.environ.get('RENGINE_RAISE_ON_ERROR', '0')))
+RENGINE_HOME = env('RENGINE_HOME', default='/usr/src/app')
+RENGINE_RESULTS = env('RENGINE_RESULTS', default=f'{RENGINE_HOME}/scan_results')
+RENGINE_CACHE_ENABLED = env.bool('RENGINE_CACHE_ENABLED', default=False)
+RENGINE_RECORD_ENABLED = env.bool('RENGINE_RECORD_ENABLED', default=True)
+RENGINE_RAISE_ON_ERROR = env.bool('RENGINE_RAISE_ON_ERROR', default=False)
 
 # Common env vars
-DEBUG = bool(int(os.environ.get('DEBUG', '0')))
-DOMAIN_NAME = os.environ.get('DOMAIN_NAME', 'localhost:8000')
-TEMPLATE_DEBUG = bool(int(os.environ.get('TEMPLATE_DEBUG', '0')))
+DEBUG = env.bool('DEBUG', default=False)
+DOMAIN_NAME = env('DOMAIN_NAME', default='localhost:8000')
+TEMPLATE_DEBUG = env.bool('TEMPLATE_DEBUG', default=False)
 SECRET_FILE = os.path.join(RENGINE_HOME, 'secret')
-DEFAULT_ENABLE_HTTP_CRAWL = bool(int(os.environ.get('DEFAULT_ENABLE_HTTP_CRAWL', '1')))
-DEFAULT_RATE_LIMIT = int(os.environ.get('DEFAULT_RATE_LIMIT', '150')) # requests / second
-DEFAULT_HTTP_TIMEOUT = int(os.environ.get('DEFAULT_HTTP_TIMEOUT', '5')) # seconds
-DEFAULT_RETRIES = int(os.environ.get('DEFAULT_RETRIES', '1'))
-DEFAULT_THREADS = int(os.environ.get('DEFAULT_THREADS', '30'))
-DEFAULT_GET_GPT_REPORT = bool(int(os.environ.get('DEFAULT_GET_GPT_REPORT', '1')))
+DEFAULT_ENABLE_HTTP_CRAWL = env.bool('DEFAULT_ENABLE_HTTP_CRAWL', default=True)
+DEFAULT_RATE_LIMIT = env.int('DEFAULT_RATE_LIMIT', default=150) # requests / second
+DEFAULT_HTTP_TIMEOUT = env.int('DEFAULT_HTTP_TIMEOUT', default=5) # seconds
+DEFAULT_RETRIES = env.int('DEFAULT_RETRIES', default=1)
+DEFAULT_THREADS = env.int('DEFAULT_THREADS', default=30)
+DEFAULT_GET_GPT_REPORT = env.bool('DEFAULT_GET_GPT_REPORT', default=True)
 
 # Globals
 ALLOWED_HOSTS = ['*']
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = first_run(SECRET_FILE, BASE_DIR)
 
 # Databases
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.environ.get('POSTGRES_DB'),
-        'USER': os.environ.get('POSTGRES_USER'),
-        'PASSWORD': os.environ.get('POSTGRES_PASSWORD'),
-        'HOST': os.environ.get('POSTGRES_HOST'),
-        'PORT': os.environ.get('POSTGRES_PORT'),
+        'NAME': env('POSTGRES_DB'),
+        'USER': env('POSTGRES_USER'),
+        'PASSWORD': env('POSTGRES_PASSWORD'),
+        'HOST': env('POSTGRES_HOST'),
+        'PORT': env('POSTGRES_PORT'),
         # 'OPTIONS':{
         #     'sslmode':'verify-full',
         #     'sslrootcert': os.path.join(BASE_DIR, 'ca-certificate.crt')
@@ -175,8 +183,8 @@ DELETE_DUPLICATES_THRESHOLD = 10
 '''
 CELERY settings
 '''
-CELERY_BROKER_URL = os.environ.get("CELERY_BROKER", "redis://redis:6379/0")
-CELERY_RESULT_BACKEND = os.environ.get("CELERY_BROKER", "redis://redis:6379/0")
+CELERY_BROKER_URL = env("CELERY_BROKER", default="redis://redis:6379/0")
+CELERY_RESULT_BACKEND = env("CELERY_BROKER", default="redis://redis:6379/0")
 CELERY_ENABLE_UTC = False
 CELERY_TIMEZONE = 'UTC'
 CELERY_IGNORE_RESULTS = False

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -37,3 +37,4 @@ whatportis
 weasyprint==53.3
 wafw00f==2.2.0
 xmltodict==0.13.0
+django-environ==0.11.2


### PR DESCRIPTION
[django-environ](https://django-environ.readthedocs.io/) provides a clean interface to interact and cast settings from os.environ, allowing those to be replaced with a local `.env` file.

It also supports (my main reason to introduce it) `X_FILE` docker-like syntax, that will populate the enviornment variable `X` with the content of the file specified in `X_FILE`

Such as:

```yaml
environment:
  PGPASSWORD_FILE: /run/secrets/pgpassword
```