### PR TITLE
Added SAN extension to the generated certs

### DIFF
--- a/certs/entrypoint.sh
+++ b/certs/entrypoint.sh
@@ -19,16 +19,21 @@ cert() {
      -out ${FILENAME}.csr \
      -subj "/C=${COUNTRY_CODE}/ST=${STATE}/L=${CITY}/O=${COMPANY}/CN=${COMMON_NAME}"
 
+  # Creating SAN extension which is needed by modern browsers
+  echo "subjectAltName=DNS:${COMMON_NAME}" > client-ext.cnf
+
   # Create a new certificate using our own CA
   openssl x509 -req -sha256 -passin pass:${AUTHORITY_PASSWORD} -days 3650 \
     -in ${FILENAME}.csr -CA ca.crt -CAkey ca.key \
-    -out ${FILENAME}.crt
+    -out ${FILENAME}.crt \
+    -extfile client-ext.cnf
 
   # Rename files and remove useless ones
   mv ${FILENAME}.crt ${FILENAME}.pem
   cp ca.crt ${FILENAME}_chain.pem
   mv ${FILENAME}.key ${FILENAME}_rsa.key
   rm ${FILENAME}.csr
+  rm client-ext.cnf
 }
 
 # Create /certs folder if it does not exist


### PR DESCRIPTION
This is necessary, since modern browsers expect the domain name in the SAN extension. Due to the fact that HSTS is used, one cannot access the web ui even if the cert is added to the system's truststore.

While signing the certificate, a subjectAltName (SAN) extension for the CN is added using a temporary configuration file which in the end gets removed.

Tested in a Digital Ocean droplet. Before the change, I was not able to access the web ui using Chrome or Firefox on my Mac.

