### PR TITLE
fix context key error #1263 #1209

### DIFF
--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -1731,7 +1731,7 @@ def dir_file_fuzz(self, ctx={}, description=None):
 			dirscan.save()
 
 			# Get subdomain and add dirscan
-			if ctx['subdomain_id'] > 0:
+			if ctx.get('subdomain_id', 0) > 0:
 				subdomain = Subdomain.objects.get(id=ctx['subdomain_id'])
 			else:
 				subdomain_name = get_subdomain_from_url(endpoint.http_url)


### PR DESCRIPTION
Fixes Context key error on subdomain id

Fixes #1209, #1263