### PR TITLE
Fix #1291 Refactor Makefiles for windows/linux to accomodate both v1 and v2 of docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,59 +9,63 @@ COMPOSE_PREFIX_CMD := COMPOSE_DOCKER_CLI_BUILD=1
 COMPOSE_ALL_FILES := -f docker-compose.yml
 SERVICES          := db web proxy redis celery celery-beat ollama
 
+# Check if 'docker compose' command is available, otherwise use 'docker-compose'
+DOCKER_COMPOSE := $(shell if command -v docker > /dev/null && docker compose version > /dev/null 2>&1; then echo "docker compose"; else echo "docker-compose"; fi)
+$(info Using: $(shell echo "$(DOCKER_COMPOSE)"))
+
 # --------------------------
 
 .PHONY: setup certs up build username pull down stop restart rm logs
 
 certs:		    ## Generate certificates.
-	@${COMPOSE_PREFIX_CMD} docker compose -f docker-compose.setup.yml run --rm certs
+	@${COMPOSE_PREFIX_CMD} ${DOCKER_COMPOSE} -f docker-compose.setup.yml run --rm certs
 
 setup:			## Generate certificates.
 	@make certs
 
 up:				## Build and start all services.
-	${COMPOSE_PREFIX_CMD} docker compose ${COMPOSE_ALL_FILES} up -d --build ${SERVICES}
+	${COMPOSE_PREFIX_CMD} ${DOCKER_COMPOSE} ${COMPOSE_ALL_FILES} up -d --build ${SERVICES}
 
 build:			## Build all services.
-	${COMPOSE_PREFIX_CMD} docker compose ${COMPOSE_ALL_FILES} build ${SERVICES}
+	${COMPOSE_PREFIX_CMD} ${DOCKER_COMPOSE} ${COMPOSE_ALL_FILES} build ${SERVICES}
 
 username:		## Generate Username (Use only after make up).
 ifeq ($(isNonInteractive), true)
-	${COMPOSE_PREFIX_CMD} docker compose ${COMPOSE_ALL_FILES} exec web python3 manage.py createsuperuser --username ${DJANGO_SUPERUSER_USERNAME} --email ${DJANGO_SUPERUSER_EMAIL} --noinput
+	${COMPOSE_PREFIX_CMD} ${DOCKER_COMPOSE} ${COMPOSE_ALL_FILES} exec web python3 manage.py createsuperuser --username ${DJANGO_SUPERUSER_USERNAME} --email ${DJANGO_SUPERUSER_EMAIL} --noinput
 else
-	${COMPOSE_PREFIX_CMD} docker compose ${COMPOSE_ALL_FILES} exec web python3 manage.py createsuperuser
+	${COMPOSE_PREFIX_CMD} ${DOCKER_COMPOSE} ${COMPOSE_ALL_FILES} exec web python3 manage.py createsuperuser
 endif
 
 changepassword:	## Change password for user
-	${COMPOSE_PREFIX_CMD} docker compose ${COMPOSE_ALL_FILES} exec web python3 manage.py changepassword
+	${COMPOSE_PREFIX_CMD} ${DOCKER_COMPOSE} ${COMPOSE_ALL_FILES} exec web python3 manage.py changepassword
 
 migrate:		## Apply migrations
-	${COMPOSE_PREFIX_CMD} docker compose ${COMPOSE_ALL_FILES} exec web python3 manage.py migrate
+	${COMPOSE_PREFIX_CMD} ${DOCKER_COMPOSE} ${COMPOSE_ALL_FILES} exec web python3 manage.py migrate
 
 pull:			## Pull Docker images.
 	docker login docker.pkg.github.com
-	${COMPOSE_PREFIX_CMD} docker compose ${COMPOSE_ALL_FILES} pull
+	${COMPOSE_PREFIX_CMD} ${DOCKER_COMPOSE} ${COMPOSE_ALL_FILES} pull
 
 down:			## Down all services.
-	${COMPOSE_PREFIX_CMD} docker compose ${COMPOSE_ALL_FILES} down
+	${COMPOSE_PREFIX_CMD} ${DOCKER_COMPOSE} ${COMPOSE_ALL_FILES} down
 
 stop:			## Stop all services.
-	${COMPOSE_PREFIX_CMD} docker compose ${COMPOSE_ALL_FILES} stop ${SERVICES}
+	${COMPOSE_PREFIX_CMD} ${DOCKER_COMPOSE} ${COMPOSE_ALL_FILES} stop ${SERVICES}
 
 restart:		## Restart all services.
-	${COMPOSE_PREFIX_CMD} docker compose ${COMPOSE_ALL_FILES} restart ${SERVICES}
+	${COMPOSE_PREFIX_CMD} ${DOCKER_COMPOSE} ${COMPOSE_ALL_FILES} restart ${SERVICES}
 
 rm:				## Remove all services containers.
-	${COMPOSE_PREFIX_CMD} docker compose $(COMPOSE_ALL_FILES) rm -f ${SERVICES}
+	${COMPOSE_PREFIX_CMD} ${DOCKER_COMPOSE} $(COMPOSE_ALL_FILES) rm -f ${SERVICES}
 
 test:
-	${COMPOSE_PREFIX_CMD} docker compose $(COMPOSE_ALL_FILES) exec celery python3 -m unittest tests/test_scan.py
+	${COMPOSE_PREFIX_CMD} ${DOCKER_COMPOSE} $(COMPOSE_ALL_FILES) exec celery python3 -m unittest tests/test_scan.py
 
 logs:			## Tail all logs with -n 1000.
-	${COMPOSE_PREFIX_CMD} docker compose $(COMPOSE_ALL_FILES) logs --follow --tail=1000 ${SERVICES}
+	${COMPOSE_PREFIX_CMD} ${DOCKER_COMPOSE} $(COMPOSE_ALL_FILES) logs --follow --tail=1000 ${SERVICES}
 
 images:			## Show all Docker images.
-	${COMPOSE_PREFIX_CMD} docker compose $(COMPOSE_ALL_FILES) images ${SERVICES}
+	${COMPOSE_PREFIX_CMD} ${DOCKER_COMPOSE} $(COMPOSE_ALL_FILES) images ${SERVICES}
 
 prune:			## Remove containers and delete volume data.
 	@make stop && make rm && docker volume prune -f

--- a/make.bat
+++ b/make.bat
@@ -6,12 +6,13 @@ set COMPOSE_ALL_FILES  = -f docker-compose.yml
 set SERVICES           = db web proxy redis celery celery-beat ollama
 
 :: Check if 'docker compose' command is available
-where docker-compose >nul 2>&1
+docker compose version >nul 2>&1
 if %errorlevel% == 0 (
-    set DOCKER_COMPOSE=docker-compose
-) else (
     set DOCKER_COMPOSE=docker compose
+) else (
+    set DOCKER_COMPOSE=docker-compose
 )
+
 
 :: Generate certificates.
 if "%1" == "certs" %DOCKER_COMPOSE% -f docker-compose.setup.yml run --rm certs

--- a/make.bat
+++ b/make.bat
@@ -3,35 +3,43 @@
 :: Credits: https://github.com/ninjhacks
 
 set COMPOSE_ALL_FILES  = -f docker-compose.yml
-set SERVICES           = db web proxy redis celery celery-beat
+set SERVICES           = db web proxy redis celery celery-beat ollama
+
+:: Check if 'docker compose' command is available
+where docker-compose >nul 2>&1
+if %errorlevel% == 0 (
+    set DOCKER_COMPOSE=docker-compose
+) else (
+    set DOCKER_COMPOSE=docker compose
+)
 
 :: Generate certificates.
-if "%1" == "certs" docker compose -f docker-compose.setup.yml run --rm certs
+if "%1" == "certs" %DOCKER_COMPOSE% -f docker-compose.setup.yml run --rm certs
 :: Generate certificates.
-if "%1" == "setup" docker compose -f docker-compose.setup.yml run --rm certs
+if "%1" == "setup" %DOCKER_COMPOSE% -f docker-compose.setup.yml run --rm certs
 :: Build and start all services.
-if "%1" == "up" docker compose %COMPOSE_ALL_FILES% up -d --build %SERVICES%
+if "%1" == "up" %DOCKER_COMPOSE% %COMPOSE_ALL_FILES% up -d --build %SERVICES%
 :: Build all services.
-if "%1" == "build" docker compose %COMPOSE_ALL_FILES% build %SERVICES%
+if "%1" == "build" %DOCKER_COMPOSE% %COMPOSE_ALL_FILES% build %SERVICES%
 :: Generate Username (Use only after make up).
-if "%1" == "username" docker-compose %COMPOSE_ALL_FILES% exec web python3 manage.py createsuperuser
+if "%1" == "username" %DOCKER_COMPOSE% %COMPOSE_ALL_FILES% exec web python3 manage.py createsuperuser
 :: Apply migrations
-if "%1" == "migrate" docker-compose %COMPOSE_ALL_FILES% exec web python3 manage.py migrate
+if "%1" == "migrate" %DOCKER_COMPOSE% %COMPOSE_ALL_FILES% exec web python3 manage.py migrate
 :: Pull Docker images.
-if "%1" == "pull" docker login docker.pkg.github.com & docker-compose %COMPOSE_ALL_FILES% pull
+if "%1" == "pull" %DOCKER_COMPOSE% docker.pkg.github.com & docker-compose %COMPOSE_ALL_FILES% pull
 :: Down all services.
-if "%1" == "down" docker compose %COMPOSE_ALL_FILES% down
+if "%1" == "down" %DOCKER_COMPOSE% %COMPOSE_ALL_FILES% down
 :: Stop all services.
-if "%1" == "stop" docker compose %COMPOSE_ALL_FILES% stop %SERVICES%
+if "%1" == "stop" %DOCKER_COMPOSE% %COMPOSE_ALL_FILES% stop %SERVICES%
 :: Restart all services.
-if "%1" == "restart" docker compose %COMPOSE_ALL_FILES% restart %SERVICES%
+if "%1" == "restart" %DOCKER_COMPOSE% %COMPOSE_ALL_FILES% restart %SERVICES%
 :: Remove all services containers.
-if "%1" == "rm" docker compose %COMPOSE_ALL_FILES% rm -f %SERVICES%
+if "%1" == "rm" %DOCKER_COMPOSE% %COMPOSE_ALL_FILES% rm -f %SERVICES%
 :: Tail all logs with -n 1000.
-if "%1" == "logs" docker compose %COMPOSE_ALL_FILES% logs --follow --tail=1000 %SERVICES%
+if "%1" == "logs" %DOCKER_COMPOSE% %COMPOSE_ALL_FILES% logs --follow --tail=1000 %SERVICES%
 :: Show all Docker images.
-if "%1" == "images" docker compose %COMPOSE_ALL_FILES% images %SERVICES%
+if "%1" == "images" %DOCKER_COMPOSE% %COMPOSE_ALL_FILES% images %SERVICES%
 :: Remove containers and delete volume data.
-if "%1" == "prune" docker compose %COMPOSE_ALL_FILES% stop %SERVICES% & docker-compose %COMPOSE_ALL_FILES% rm -f %SERVICES% & docker volume prune -f
+if "%1" == "prune" %DOCKER_COMPOSE% %COMPOSE_ALL_FILES% stop %SERVICES% & docker-compose %COMPOSE_ALL_FILES% rm -f %SERVICES% & docker volume prune -f
 :: Show this help.
 if "%1" == "help" @echo Make application Docker images and manage containers using Docker Compose files only for windows.


### PR DESCRIPTION
Docker compose v2 uses `docker compose` while earlier versions use `docker-compose`

@0xKayala reported that in Kali makefile script was not working. Likely due to older version of docker compose.

@calincoj mentioned replacing `docker compose` with `docker-compose` suggesting that older version is installed and rest of installation just works fine.

This PR checks for `docker compose` by default else uses `docker-compose`