### PR TITLE
Optimize uninstall scripts to perform operations only related to reNgine Fixes # 1187

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -115,15 +115,11 @@ services:
       - rengine_network
   ollama:
     image: ollama/ollama
-    container_name: ollama
     volumes:
       - ollama_data:/root/.ollama
-    # ports:
-    #   - "11434:11434"
     networks:
       - rengine_network
     restart: always
-    # command: ["ollama", "run", "llama2-uncensored"]
 
 networks:
   rengine_network:


### PR DESCRIPTION
reNgine uninstall script has been optimized to perform operations such as stopping the container, deleting the containers, and volumes that are only related to reNgine. This will also remove build cache objects related to reNgine intsllation. 