### PR TITLE
feat(ci): ci for automated un(install) of reNgine on the fly; fixed shellcheck warns

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -3,10 +3,10 @@ name: Run ShellCheck on sh files
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   shellcheck:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,36 @@
+name: Run ShellCheck on sh files
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Install ShellCheck
+      run: |
+        echo "Installing ShellCheck..."
+        sudo apt-get update
+        sudo apt-get install -y shellcheck
+
+    - name: Run ShellCheck on .sh files
+      run: |
+        echo "Searching for .sh files..."
+        sh_files=$(find . -type f -name "*.sh")
+        if [ -z "$sh_files" ]; then
+          echo "No shell script files found."
+          exit 0
+        else
+          for file in $sh_files; do
+            echo "Running ShellCheck on $file..."
+            shellcheck "$file"
+          done
+        fi

--- a/.github/workflows/test-rengine.yml
+++ b/.github/workflows/test-rengine.yml
@@ -1,0 +1,34 @@
+name: Install rengine inside GH CI for test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  install_base:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install base using install.sh (non-interactive mode)
+        run: |
+          bash ./install.sh -n
+
+      - name: Install Chrome and hxn
+        run: |
+          which google-chrome >/dev/null 2>&1 && echo "Chrome already installed" || sudo apt install -y google-chrome
+          cargo install hxn && echo "hxn installed"
+
+      - name: Take screenshot of the app
+        run: |
+          hxn -b $(which google-chrome) -u http://127.0.0.1:8000 -o $(pwd)
+          
+      - name: Upload it to 0x0.st
+        run: |
+          curl -s -F "file=@httplocalhost8000.png" https://0x0.st

--- a/.github/workflows/test-rengine.yml
+++ b/.github/workflows/test-rengine.yml
@@ -30,10 +30,8 @@ jobs:
 
       - name: Take screenshot of the app
         run: |
-          ls -lah
           hxn -b $(which google-chrome) -u http://127.0.0.1:8000 -o $(pwd)
-          ls -lah
           
       - name: Upload it to 0x0.st
         run: |
-          curl -s -F "file=@httplocalhost8000.png" https://0x0.st
+          curl -s -F "file=@http1270018000.png" https://0x0.st

--- a/.github/workflows/test-rengine.yml
+++ b/.github/workflows/test-rengine.yml
@@ -40,4 +40,4 @@ jobs:
 
       - name: Gracefullly removing rengine
         run: |
-          sudo bash ./scripts/uninstall.sh
+          yes | sudo bash ./scripts/uninstall.sh

--- a/.github/workflows/test-rengine.yml
+++ b/.github/workflows/test-rengine.yml
@@ -18,8 +18,10 @@ jobs:
 
       - name: Install base using install.sh (non-interactive mode)
         run: |
+          pwd
+          ls -lah
           export TERM=${TERM:-xterm}
-          sudo ./install.sh -n
+          sudo bash ./install.sh -n
 
       - name: Install Chrome and hxn
         run: |

--- a/.github/workflows/test-rengine.yml
+++ b/.github/workflows/test-rengine.yml
@@ -24,11 +24,15 @@ jobs:
       - name: Install Chrome and hxn
         run: |
           which google-chrome >/dev/null 2>&1 && echo "Chrome already installed" || sudo apt install -y google-chrome
-          cargo install hxn && echo "hxn installed"
+          wget https://github.com/pwnwriter/haylxon/releases/download/v1.0.0/haylxon-1.0.0-x86_64-unknown-linux-gnu.tar.gz
+          tar -xvf haylxon-1.0.0-x86_64-unknown-linux-gnu.tar.gz
+          sudo mv haylxon-1.0.0/hxn /usr/local/bin/hxn && echo "hxn installed"
 
       - name: Take screenshot of the app
         run: |
+          ls -lah
           hxn -b $(which google-chrome) -u http://127.0.0.1:8000 -o $(pwd)
+          ls -lah
           
       - name: Upload it to 0x0.st
         run: |

--- a/.github/workflows/test-rengine.yml
+++ b/.github/workflows/test-rengine.yml
@@ -18,7 +18,8 @@ jobs:
 
       - name: Install base using install.sh (non-interactive mode)
         run: |
-          bash ./install.sh -n
+          export TERM=${TERM:-xterm}
+          sudo ./install.sh -n
 
       - name: Install Chrome and hxn
         run: |

--- a/.github/workflows/test-rengine.yml
+++ b/.github/workflows/test-rengine.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install base using install.sh (non-interactive mode)
         run: |

--- a/.github/workflows/test-rengine.yml
+++ b/.github/workflows/test-rengine.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Install base using install.sh (non-interactive mode)
         run: |
-          pwd
-          ls -lah
           export TERM=${TERM:-xterm}
           sudo bash ./install.sh -n
 

--- a/.github/workflows/test-rengine.yml
+++ b/.github/workflows/test-rengine.yml
@@ -3,10 +3,10 @@ name: Install rengine inside GH CI for test
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   install_base:

--- a/.github/workflows/test-rengine.yml
+++ b/.github/workflows/test-rengine.yml
@@ -19,6 +19,8 @@ jobs:
       - name: Install base using install.sh (non-interactive mode)
         run: |
           export TERM=${TERM:-xterm}
+          chmod +x ./install.sh
+          chmod +x ./scripts/uninstall.sh
           sudo bash ./install.sh -n
 
       - name: Install Chrome and hxn
@@ -35,3 +37,7 @@ jobs:
       - name: Upload it to 0x0.st
         run: |
           curl -s -F "file=@http1270018000.png" https://0x0.st
+
+      - name: Gracefullly removing rengine
+        run: |
+          sudo bash ./scripts/uninstall.sh

--- a/install.sh
+++ b/install.sh
@@ -2,55 +2,69 @@
 
 # Display usage
 usage_function() {
-  echo " "
-  tput setaf 2
-  echo "Usage: $0 [-n] [-h]"
-  echo -e "\t-n Non-interactive installation (Optional)"
-  echo -e "\t-h Show usage"
-  exit 1
+    echo " "
+    tput setaf 2
+    echo "Usage: $0 [-n] [-h]"
+    echo -e "\t-n Non-interactive installation (Optional)"
+    echo -e "\t-h Show usage"
+    exit 1
 }
 
 # Print success messages
 success_message() {
-  tput setaf 2
-  echo "$1"
+    tput setaf 2
+    echo "$1"
 }
 
 # Print error messages
 error_message() {
-  tput setaf 1
-  echo "$1"
+    tput setaf 1
+    echo "$1"
 }
 
 # Print informational messages
 info_message() {
-  tput setaf 4
-  echo "$1"
+    tput setaf 4
+    echo "$1"
 }
 
 # Check and install packages
 install_package() {
-  local package=$1
-  local install_command=$2
-  if [ -x "$(command -v $package)" ]; then
-    success_message "$package already installed, skipping."
-  else
-    info_message "Installing $package..."
-    eval $install_command
-    success_message "$package installed!"
-  fi
+    local package=$1
+    local install_command=$2
+    if [ -x "$(command -v "$package")" ]; then
+        success_message "$package already installed, skipping."
+    else
+        info_message "Installing $package..."
+        eval "$install_command"
+        success_message "$package installed!"
+    fi
 }
 
-# Function to check Docker status
+# Check Docker status
 check_docker_status() {
-  if docker info >/dev/null 2>&1; then
-    success_message "Docker is running."
-  else
-    error_message "Docker is not running. Please start Docker and try again."
-    error_message "You can start Docker using: sudo systemctl start docker"
-    exit 1
-  fi
+    if docker info >/dev/null 2>&1; then
+        success_message "Docker is running."
+    else
+        error_message "Docker is not running. Please start Docker and try again."
+        error_message "You can start Docker using: sudo systemctl start docker"
+        exit 1
+    fi
 }
+
+check_apt() {
+    if command -v apt >/dev/null 2>&1; then
+        success_message "apt package manager is available, proceeding..."
+    else
+        info_message "############################################################################################"
+        info_message "This installation script is intended for Debian (based) Linux distros only."
+        info_message "For Mac and Windows, refer to the official guide: https://rengine.wiki"
+        info_message "############################################################################################"
+        exit 0
+    fi
+}
+
+check_apt
 
 # Display initial information
 info_message "$(cat web/art/reNgine.txt)"
@@ -60,39 +74,33 @@ success_message "Changing the postgres username & password from .env is highly r
 # Parse command-line options
 is_non_interactive=false
 while getopts "nh" opt; do
-  case $opt in
-    n) is_non_interactive=true ;;
-    h) usage_function ;;
-    ?) usage_function ;;
-  esac
+    case $opt in
+        n) is_non_interactive=true ;;
+        h) usage_function ;;
+        ?) usage_function ;;
+    esac
 done
 
 # Confirm .env file changes if not in non-interactive mode
 if [ "$is_non_interactive" = false ]; then
-  read -p "Are you sure you have made changes to the .env file (y/n)? " answer
-  case ${answer:0:1} in
-    y|Y|yes|YES|Yes )
-      success_message "Continuing Installation!"
-      ;;
-    * )
-      nano .env
-      ;;
-  esac
+    read -r -p "Are you sure you have made changes to the .env file (y/n)? " answer
+    case ${answer:0:1} in
+        y | Y | yes | YES | Yes)
+            success_message "Continuing Installation!"
+            ;;
+        *)
+            nano .env
+            ;;
+    esac
 else
-  success_message "Non-interactive installation parameter set. Installation begins."
+    success_message "Non-interactive installation parameter set. Installation begins."
 fi
-
-# Display general installation information
-info_message "############################################################################################"
-info_message "This installation script is intended for Debian (based) Linux distros only."
-info_message "For Mac and Windows, refer to the official guide: https://rengine.wiki"
-info_message "############################################################################################"
 
 # Check for root privileges
 if [ "$EUID" -ne 0 ]; then
-  error_message "Error: This script must be run as root!"
-  error_message "Example: sudo ./install.sh"
-  exit 1
+    error_message "Error: This script must be run as root!"
+    error_message "Example: sudo ./install.sh"
+    exit 1
 fi
 
 # Install necessary packages
@@ -108,21 +116,20 @@ check_docker_status
 info_message "#########################################################################"
 info_message "Installing reNgine"
 info_message "#########################################################################"
-make certs && make build && make up
-if [ $? -eq 0 ]; then
-  success_message "reNgine is installed!"
-  sleep 3
-  info_message "#########################################################################"
-  info_message "Creating an account"
-  info_message "#########################################################################"
-  if [ "$is_non_interactive" = true ]; then
-    make username isNonInteractive=true
-  else
-    make username
-  fi
-  make migrate
-  success_message "Thank you for installing reNgine, happy recon!"
-  echo "In case you have unapplied migrations, run 'make migrate'"
+if make certs && make build && make up; then
+    success_message "reNgine is installed!"
+    sleep 3
+    info_message "#########################################################################"
+    info_message "Creating an account"
+    info_message "#########################################################################"
+    if [ "$is_non_interactive" = true ]; then
+        make username isNonInteractive=true
+    else
+        make username
+    fi
+    make migrate
+    success_message "Thank you for installing reNgine, happy recon!"
+    echo "In case you have unapplied migrations, run 'make migrate'"
 else
-  error_message "reNgine installation failed!"
+    error_message "reNgine installation failed!"
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,153 +1,128 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-usageFunction()
-{
+# Display usage
+usage_function() {
   echo " "
-  tput setaf 2;
-  echo "Usage: $0 (-n) (-h)"
+  tput setaf 2
+  echo "Usage: $0 [-n] [-h]"
   echo -e "\t-n Non-interactive installation (Optional)"
   echo -e "\t-h Show usage"
   exit 1
 }
 
-tput setaf 2;
-cat web/art/reNgine.txt
+# Print success messages
+success_message() {
+  tput setaf 2
+  echo "$1"
+}
 
-tput setaf 1; echo "Before running this script, please make sure Docker is running and you have made changes to .env file."
-tput setaf 2; echo "Changing the postgres username & password from .env is highly recommended."
+# Print error messages
+error_message() {
+  tput setaf 1
+  echo "$1"
+}
 
-tput setaf 4;
+# Print informational messages
+info_message() {
+  tput setaf 4
+  echo "$1"
+}
 
-isNonInteractive=false
-while getopts nh opt; do
-   case $opt in
-      n) isNonInteractive=true ;;
-      h) usageFunction ;;
-      ?) usageFunction ;;
-   esac
+# Check and install packages
+install_package() {
+  local package=$1
+  local install_command=$2
+  if [ -x "$(command -v $package)" ]; then
+    success_message "$package already installed, skipping."
+  else
+    info_message "Installing $package..."
+    eval $install_command
+    success_message "$package installed!"
+  fi
+}
+
+# Function to check Docker status
+check_docker_status() {
+  if docker info >/dev/null 2>&1; then
+    success_message "Docker is running."
+  else
+    error_message "Docker is not running. Please start Docker and try again."
+    error_message "You can start Docker using: sudo systemctl start docker"
+    exit 1
+  fi
+}
+
+# Display initial information
+info_message "$(cat web/art/reNgine.txt)"
+error_message "Before running this script, please make sure Docker is running and you have updated the .env file."
+success_message "Changing the postgres username & password from .env is highly recommended."
+
+# Parse command-line options
+is_non_interactive=false
+while getopts "nh" opt; do
+  case $opt in
+    n) is_non_interactive=true ;;
+    h) usage_function ;;
+    ?) usage_function ;;
+  esac
 done
 
-if [ $isNonInteractive = false ]; then
-    read -p "Are you sure, you made changes to .env file (y/n)? " answer
-    case ${answer:0:1} in
-        y|Y|yes|YES|Yes )
-          echo "Continiuing Installation!"
-        ;;
-        * )
-          nano .env
-        ;;
-    esac
+# Confirm .env file changes if not in non-interactive mode
+if [ "$is_non_interactive" = false ]; then
+  read -p "Are you sure you have made changes to the .env file (y/n)? " answer
+  case ${answer:0:1} in
+    y|Y|yes|YES|Yes )
+      success_message "Continuing Installation!"
+      ;;
+    * )
+      nano .env
+      ;;
+  esac
 else
-  echo "Non-interactive installation parameter set. Installation begins."
+  success_message "Non-interactive installation parameter set. Installation begins."
 fi
 
-echo " "
-tput setaf 3;
-echo "#########################################################################"
-echo "Please note that, this installation script is only intended for Linux"
-echo "For Mac and Windows, refer to the official guide https://rengine.wiki"
-echo "#########################################################################"
+# Display general installation information
+info_message "############################################################################################"
+info_message "This installation script is intended for Debian (based) Linux distros only."
+info_message "For Mac and Windows, refer to the official guide: https://rengine.wiki"
+info_message "############################################################################################"
 
-echo " "
-tput setaf 4;
-echo "Installing reNgine and its dependencies"
-
-echo " "
-if [ "$EUID" -ne 0 ]
-  then
-  tput setaf 1; echo "Error installing reNgine, Please run this script as root!"
-  tput setaf 1; echo "Example: sudo ./install.sh"
-  exit
-fi
-
-echo " "
-tput setaf 4;
-echo "#########################################################################"
-echo "Installing curl..."
-echo "#########################################################################"
-if [ -x "$(command -v curl)" ]; then
-  tput setaf 2; echo "CURL already installed, skipping."
-else
-  sudo apt update && sudo apt install curl -y
-  tput setaf 2; echo "CURL installed!!!"
-fi
-
-echo " "
-tput setaf 4;
-echo "#########################################################################"
-echo "Installing Docker..."
-echo "#########################################################################"
-if [ -x "$(command -v docker)" ]; then
-  tput setaf 2; echo "Docker already installed, skipping."
-else
-  curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh
-  tput setaf 2; echo "Docker installed!!!"
-fi
-
-
-echo " "
-tput setaf 4;
-echo "#########################################################################"
-echo "Installing Docker Compose"
-echo "#########################################################################"
-if [ -x "$(command -v docker compose)" ]; then
-  tput setaf 2; echo "Docker Compose already installed, skipping."
-else
-  curl -L "https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-  chmod +x /usr/local/bin/docker-compose
-  ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
-  tput setaf 2; echo "Docker Compose installed!!!"
-fi
-
-
-echo " "
-tput setaf 4;
-echo "#########################################################################"
-echo "Installing make"
-echo "#########################################################################"
-if [ -x "$(command -v make)" ]; then
-  tput setaf 2; echo "make already installed, skipping."
-else
-  apt install make
-fi
-
-echo " "
-tput setaf 4;
-echo "#########################################################################"
-echo "Checking Docker status"
-echo "#########################################################################"
-if docker info >/dev/null 2>&1; then
-  tput setaf 4;
-  echo "Docker is running."
-else
-  tput setaf 1;
-  echo "Docker is not running. Please run docker and try again."
-  echo "You can run docker service using sudo systemctl start docker"
+# Check for root privileges
+if [ "$EUID" -ne 0 ]; then
+  error_message "Error: This script must be run as root!"
+  error_message "Example: sudo ./install.sh"
   exit 1
 fi
 
+# Install necessary packages
+install_package "curl" "sudo apt update && sudo apt install curl -y"
+install_package "docker" "curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh"
+install_package "docker-compose" "curl -L \"https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-$(uname -s)-$(uname -m)\" -o /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose && ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose"
+install_package "make" "apt install make -y"
 
+# Check Docker status
+check_docker_status
 
-echo " "
-tput setaf 4;
-echo "#########################################################################"
-echo "Installing reNgine"
-echo "#########################################################################"
-make certs && make build && make up && tput setaf 2 && echo "reNgine is installed!!!" && failed=0 || failed=1
-
-if [ "${failed}" -eq 0 ]; then
+# Install reNgine
+info_message "#########################################################################"
+info_message "Installing reNgine"
+info_message "#########################################################################"
+make certs && make build && make up
+if [ $? -eq 0 ]; then
+  success_message "reNgine is installed!"
   sleep 3
-
-  echo " "
-  tput setaf 4;
-  echo "#########################################################################"
-  echo "Creating an account"
-  echo "#########################################################################"
-  make username isNonInteractive=$isNonInteractive
+  info_message "#########################################################################"
+  info_message "Creating an account"
+  info_message "#########################################################################"
+  if [ "$is_non_interactive" = true ]; then
+    make username isNonInteractive=true
+  else
+    make username
+  fi
   make migrate
-
-  tput setaf 2 && printf "\n%s\n" "Thank you for installing reNgine, happy recon!!"
-  echo "In case you have unapplied migrations (see above in red), run 'make migrate'"
+  success_message "Thank you for installing reNgine, happy recon!"
+  echo "In case you have unapplied migrations, run 'make migrate'"
 else
-  tput setaf 1 && printf "\n%s\n" "reNgine installation failed!!"
+  error_message "reNgine installation failed!"
 fi

--- a/update.sh
+++ b/update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Do you want to apply your local changes after updating? (y/n)"
 read answer

--- a/update.sh
+++ b/update.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 echo "Do you want to apply your local changes after updating? (y/n)"
-read answer
-answer=$(echo $answer | tr '[:upper:]' '[:lower:]')
+read -r answer
+answer=$(echo "$answer" | tr '[:upper:]' '[:lower:]')
 
 if [[ $answer == "y" ]]; then
   make down && git stash save && git pull && git stash apply && make build && make up
@@ -11,3 +11,4 @@ elif [[ $answer == "n" ]]; then
 else
   echo "Invalid input. Please enter 'y' or 'n'."
 fi
+


### PR DESCRIPTION
Hello @yogeshojha,

This pull request introduces the following changes:

- **ShellCheck CI Integration:** 
  There was no continuous integration (CI) setup for ShellCheck. Since the application un(installation) is primarily based on `bash`, I have added a CI job for ShellCheck.
  - CI in action: [pwnwriter/rengine/shellcheck](https://github.com/pwnwriter/rengine/actions/runs/10081273541/job/27872923015)

- **Automated Un(install) test on the fly:**
  This PR also adds a new CI job for the automated installation and uninstallation of `rengine`. This will be helpful for any pull requests or tests.
  - CI in action: [pwnwriter/rengine/install](https://github.com/pwnwriter/rengine/actions/runs/10081273547/job/27872922785)
 
I'd like to explain a bit more on this:, This ci actually installs rengine inside the gh workflow, takes screenshot using [pwnwriter/haylxon](https://github.com/pwnwriter/haylxon) and uploads to [0x0.st](https://0x0.st),  it'll help you understand if the app is actually running or not and debug on the same. 

- **ShellCheck Warnings Fixes:**
  I have addressed ShellCheck warnings in the installation and uninstallation scripts. You'll want to do the same for other scripts based on the CI output.

If you need any further assistance or have queries, please let me know. I would be happy to help.