### PR TITLE
Fix slug while initiating periodic and clocked scan Fixes #1322

### DIFF
--- a/web/startScan/views.py
+++ b/web/startScan/views.py
@@ -797,7 +797,7 @@ def schedule_organization_scan(request, slug, id):
             messages.INFO,
             f'Scan started for {ndomains} domains in organization {organization.name}'
         )
-        return HttpResponseRedirect(reverse('scheduled_scan_view', kwargs={'slug': slug, 'id': id}))
+        return HttpResponseRedirect(reverse('scheduled_scan_view', kwargs={'slug': slug}))
 
     # GET request
     engine = EngineType.objects


### PR DESCRIPTION
Typo in initiating periodic and clocked scan causes 500 error, this PR fixes the typo.