### PR TITLE
Fix error during tool update Fixes #1152

### DIFF
--- a/web/api/views.py
+++ b/web/api/views.py
@@ -982,10 +982,14 @@ class UpdateTool(APIView):
 			tool_name = tool_name.split('/')[-1]
 			update_command = 'cd /usr/src/github/' + tool_name + ' && git pull && cd -'
 
-		run_command(update_command)
-		run_command.apply_async(args=(update_command,))
-		return Response({'status': True, 'message': tool.name + ' updated successfully.'})
-
+		
+		try:
+			run_command(update_command, shell=True)
+			run_command.apply_async(args=[update_command], kwargs={'shell': True})
+			return Response({'status': True, 'message': tool.name + ' updated successfully.'})
+		except Exception as e:
+			logger.error(str(e))
+			return Response({'status': False, 'message': str(e)})
 
 class GetExternalToolCurrentVersion(APIView):
 	def get(self, request):


### PR DESCRIPTION
This PR addresses an issue in the tool update process where the `cd` command failed to execute properly. The problem was resolved by enabling shell execution in the subprocess call.

This error occurred because `cd` is a shell built-in command, not an executable file. By setting `shell=True`, we allow the use of shell built-ins like `cd`.

- Added `shell=True` parameter to the subprocess call in the `run_command` Celery task.
