### PR TITLE
Upgrade setuptools to 72.1.0 to resolve installation error

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -106,7 +106,7 @@ RUN nuclei -update-templates
 
 # Copy requirements
 COPY ./requirements.txt /tmp/requirements.txt
-RUN pip3 install --upgrade setuptools pip && \
+RUN pip3 install --upgrade setuptools==72.1.0 pip && \
     pip3 install -r /tmp/requirements.txt --no-cache-dir
 
 # install eyewitness


### PR DESCRIPTION
Our Docker build was failing due to an error with setuptools. Specifically, we encountered a `ModuleNotFoundError: No module named 'setuptools.command.test'`. This was caused by issues with setuptools version 72.0.0, which was yanked from the repository by the package maintainers.

We've updated our Dockerfile to explicitly install setuptools version 72.1.0. This version resolves the issues present in 72.0.0 and allows our build process to complete successfully.
