### PR TITLE
(bug) Fix subdomain import for subdomains with suffix more than 4 chars Fixes #1128

### DIFF
--- a/web/reNgine/common_func.py
+++ b/web/reNgine/common_func.py
@@ -430,8 +430,29 @@ def get_domain_from_subdomain(subdomain):
 	Returns:
 		str: Domain name.
 	"""
-	ext = tldextract.extract(subdomain)
-	return '.'.join(ext[1:3])
+	# ext = tldextract.extract(subdomain)
+	# return '.'.join(ext[1:3])
+
+	if not validators.domain(subdomain):
+		return None
+	
+	# Use tldextract to parse the subdomain
+	extracted = tldextract.extract(subdomain)
+
+	# if tldextract recognized the tld then its the final result
+	if extracted.suffix:
+		domain = f"{extracted.domain}.{extracted.suffix}"
+	else:
+		# Fallback method for unknown TLDs, like .clouds or .local etc
+		parts = subdomain.split('.')
+		if len(parts) >= 2:
+			domain = '.'.join(parts[-2:])
+		else:
+			return None
+		
+	# Validate the domain before returning
+	return domain if validators.domain(domain) else None
+
 
 
 def sanitize_url(http_url):


### PR DESCRIPTION
The current `get_domain_from_subdomain` function was not accurately handling all types of subdomains, especially those with less common or new TLDs. It also lacked proper validation for the returned domains.

This PR introduces a refactored `get_domain_from_subdomain` function that combines the strengths of `tldextract`, a custom fallback method.


