### PR TITLE
Removes external IP from reNgine ui

### DIFF
--- a/web/reNgine/context_processors.py
+++ b/web/reNgine/context_processors.py
@@ -1,5 +1,3 @@
-import requests
-
 from dashboard.models import *
 from django.conf import settings
 
@@ -14,12 +12,6 @@ def projects(request):
     return {
         'projects': projects,
         'current_project': project
-    }
-
-def misc(request):
-    externalIp = requests.get('https://checkip.amazonaws.com').text.strip()
-    return {
-        'external_ip': externalIp
     }
 
 def version_context(request):

--- a/web/reNgine/settings.py
+++ b/web/reNgine/settings.py
@@ -118,7 +118,6 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
                 'reNgine.context_processors.projects',
-                'reNgine.context_processors.misc',
                 'reNgine.context_processors.version_context'
             ],
     },

--- a/web/templates/base/_items/footer.html
+++ b/web/templates/base/_items/footer.html
@@ -1,7 +1,6 @@
 <div class="footer">
   <div class="row justify-content-center">
     <div class="col-12 col-md-8 col-lg-6 justify-content-center text-center">
-      External IP : {{external_ip}}
     </div>
   </div>
 </div>

--- a/web/templates/base/base.html
+++ b/web/templates/base/base.html
@@ -92,7 +92,7 @@
         {% include 'base/_items/offcanvas.html' %}
       </div>
       {% include 'base/_items/right_bar.html' %}
-      {% include 'base/_items/footer.html' %}
+      {% comment %} {% include 'base/_items/footer.html' %} {% endcomment %}
     </div>
     <script src="{% static 'assets/js/vendor.min.js' %}"></script>
     <script src="https://unpkg.com/@popperjs/core@2"></script>


### PR DESCRIPTION
This pull request removes the AWS external IP check that was previously executed on every page of reNgine. This check was implemented in the Django context preprocessor, causing it to run unnecessarily often and potentially impacting performance.

If the external IP information is still needed in specific areas of the application, we should implement a more targeted approach, fetching it only when necessary rather than on every page load. But fetching external IP on a webpage after its logged in doesn't make any sense.
