### PR TITLE
remove redundant docker environment variables

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -74,10 +74,6 @@ RUN ARCH=$(dpkg --print-architecture) \
 # Make directory for app
 WORKDIR /usr/src/app
 
-# Set environment variables
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
-
 ENV GO111MODULE=on 
 RUN printf "\
     github.com/jaeles-project/gospider@latest\n\


### PR DESCRIPTION
Already defined in:
 https://github.com/yogeshojha/rengine/blob/20543d87cc57bb0184ff60adf2bd62b92c2c0faf/web/Dockerfile#L19-L26