### PR TITLE
chores: Add error handling for the curl command

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -56,9 +56,7 @@ RUN apt install -y --no-install-recommends \
 RUN add-apt-repository ppa:mozillateam/ppa
 
 RUN ARCH=$(dpkg --print-architecture) \ 
-    && wget https://go.dev/dl/go${GOVERSION}.linux-${ARCH}.tar.gz \
-    && tar -xvf go${GOVERSION}.linux-${ARCH}.tar.gz -C /usr/local \
-    && rm go${GOVERSION}.linux-${ARCH}.tar.gz
+    && curl -L https://go.dev/dl/go${GOVERSION}.linux-${ARCH}.tar.gz | tar -xzC /usr/local
 
 RUN ARCH=$(dpkg --print-architecture) \ 
     && if [ "${ARCH}" = "arm64" ]; then \
@@ -72,7 +70,7 @@ RUN ARCH=$(dpkg --print-architecture) \
     && mv geckodriver /usr/bin
 
 # Install Rust for orjson
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN set -e; curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN pip3 install maturin
 
@@ -107,8 +105,8 @@ RUN nuclei -update-templates
 
 # Copy requirements
 COPY ./requirements.txt /tmp/requirements.txt
-RUN pip3 install --upgrade setuptools==72.1.0
-RUN pip3 install -r /tmp/requirements.txt --no-cache-dir
+RUN pip3 install --upgrade setuptools==72.1.0 && \
+    pip3 install -r /tmp/requirements.txt --no-cache-dir
 
 # install eyewitness
 RUN pip3 install --no-cache-dir fuzzywuzzy \

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -105,8 +105,8 @@ RUN nuclei -update-templates
 
 # Copy requirements
 COPY ./requirements.txt /tmp/requirements.txt
-RUN pip3 install --upgrade setuptools==72.1.0 && \
-    pip3 install -r /tmp/requirements.txt --no-cache-dir
+RUN pip3 install --upgrade setuptools==72.1.0
+RUN pip3 install -r /tmp/requirements.txt --no-cache-dir
 
 # install eyewitness
 RUN pip3 install --no-cache-dir fuzzywuzzy \


### PR DESCRIPTION
* Replace the use of `wget` and `tar` commands with a single `curl` command that pipes
directly to tar to streamline the installation process and reduce the number of
intermediate steps and potential points of failure.

* Add error handling for the `curl` command used to install Rust to ensure the script
stops on any errors during the download or installation process.
