### PR TITLE
Update of template.html with conditional statement

### DIFF
--- a/web/templates/report/template.html
+++ b/web/templates/report/template.html
@@ -939,7 +939,10 @@
               <div>
                 <h4 class="content-heading" id="vuln_{{vulnerability.name.split|join:'_'}}">
                   <span>{{vulnerability.name}}
-                    <br>in {{vulnerabilities.grouper}}</span>
+                    {% if vulnerabilities.grouper %}
+                    <br>in {{vulnerabilities.grouper}}
+                    {% endif %}
+                  </span>
                   {% if vulnerability.severity == -1 %}
                     <span style="float: right;" class="badge bg-grey">Unknown</span>
                     <div class="grey-hr-line" ></div>


### PR DESCRIPTION
TLDR; Added boolean operator to report template. This mitigates having a listed vulnerability with the "in" preposition, when no URL/URI is present.


When generating reports, if a reported vulnerability does not have a specific URL/URI, the report will generate according to the following syntax (regardless of whether the URL is present or not): 
`<Vulnerability name> in <URL>`

This often results in a report with vulnerability headings appearing incomplete like: WAF detected in 

This change updates template.html file with a conditional check, avoiding this issue.

Vulnerability headings without a URL omit the "in" preposition.