### PR TITLE
feat: Enhanced Out of Scope Subdomain Checking, Support for regex in out of scope scan parameter #1358 

### DIFF
--- a/web/reNgine/utilities.py
+++ b/web/reNgine/utilities.py
@@ -1,3 +1,4 @@
+import re
 import os
 import validators
 
@@ -114,3 +115,47 @@ def is_valid_url(url, validate_only_http_scheme=True):
 			return url.startswith('http://') or url.startswith('https://')
 		return True
 	return False
+
+
+class SubdomainScopeChecker:
+	"""
+		SubdomainScopeChecker is a utility class to check if a subdomain is in scope or not.
+		it supports both regex and string matching.
+	"""
+
+	def __init__(self, patterns):
+		self.regex_patterns = set()
+		self.plain_patterns = set()
+		self.load_patterns(patterns)
+
+	def load_patterns(self, patterns):
+		"""
+			Load patterns into the checker.
+
+			Args:
+				patterns (list): List of patterns to load.
+			Returns: 
+				None
+		"""
+		for pattern in patterns:
+			# skip empty patterns
+			if not pattern:
+				continue
+			try:
+				self.regex_patterns.add(re.compile(pattern, re.IGNORECASE))
+			except re.error:
+				self.plain_patterns.add(pattern.lower())
+
+	def is_out_of_scope(self, subdomain):
+		"""
+			Check if a subdomain is out of scope.
+
+			Args:
+				subdomain (str): The subdomain to check.
+			Returns:
+				bool: True if the subdomain is out of scope, False otherwise.
+		"""
+		subdomain = subdomain.lower() # though we wont encounter this, but just in case
+		if subdomain in self.plain_patterns:
+			return True
+		return any(pattern.search(subdomain) for pattern in self.regex_patterns)

--- a/web/startScan/templates/startScan/_items/schedule_scan_wizard.html
+++ b/web/startScan/templates/startScan/_items/schedule_scan_wizard.html
@@ -75,14 +75,15 @@
                                 <textarea class="form-control" id="importSubdomainFormControlTextarea" name="importSubdomainTextArea" rows="6" spellcheck="false"></textarea>
                             </div>
                             <div class="mb-3">
-                                <h4 class="text-warning">Out of Scope Subdomains(Optional)</h4>
-                                <span class="">You can import subdomains for <b>{{domain.name}}</b> using your private recon tools.</span>
-                                <br>
-                                <div class="alert bg-soft-warning border-0 mt-1 mb-1" role="alert">
-                                    <span class="">Separate the out of scope subdomains/keywords using new line.(No regex currently supported.)</span>
+                                <h4 class="text-warning">Out of Scope Subdomains (Optional)</h4>
+                                <p>Specify subdomains of <strong>{{domain.name}}</strong> to exclude from scanning. These subdomains will be omitted from all subsequent scans, including URL discovery and vulnerability assessments.</p>
+                                <p>Enter one subdomain or pattern per line. Both plain text and regex patterns are supported. <span class="badge bg-soft-primary text-primary ms-2">New</span></p>
+                                <div class="mt-2 mb-2">
+                                <li>For plain text: <code>admin.example.com</code></li>
+                                <li>For regex: <code>^.*outofscope.*\.com$</code>, <code>admin.*</code> etc</li>
                                 </div>
                                 <label for="outOfScopeSubdomainTextarea" class="form-label mt-1">Out of Scope Subdomains List</label>
-                                <textarea class="form-control" id="outOfScopeSubdomainTextarea" name="outOfScopeSubdomainTextarea" rows="6" spellcheck="false"></textarea>
+                                <textarea class="form-control" id="outOfScopeSubdomainTextarea" name="outOfScopeSubdomainTextarea" rows="6" spellcheck="false" placeholder="Enter subdomains or patterns, one per line"></textarea>
                             </div>
                         </div>
                         <h3>URL Scope and Exclusions</h3>

--- a/web/startScan/templates/startScan/_items/start_scan_wizard.html
+++ b/web/startScan/templates/startScan/_items/start_scan_wizard.html
@@ -28,23 +28,24 @@
             <div class="">
               <div class="mb-3">
                 <h4 class="text-info">Import Subdomains(Optional)</h4>
-                <span class="">You can import subdomains for <b>{{domain.name}}</b> using your private recon tools.</span>
+                <p>You can import subdomains for <strong>{{domain.name}}</strong> discovered through your private reconnaissance tools.</p>
                 <br>
                 <div class="alert bg-soft-primary border-0 mt-1 mb-1" role="alert">
-                  <span class="">Separate the subdomains using <b>new line</b>. If the subdomain does not belong to <b>{{domain.name}}</b> it will be skipped.</span>
+                  <span>Enter one subdomain per line. Subdomains not belonging to <strong>{{domain.name}}</strong> will be automatically skipped.</span>
                 </div>
                 <label for="importSubdomainFormControlTextarea" class="form-label mt-1">Subdomains List</label>
                 <textarea class="form-control" id="importSubdomainFormControlTextarea" name="importSubdomainTextArea" rows="6" spellcheck="false"></textarea>
               </div>
               <div class="mb-3">
-                <h4 class="text-warning">Out of Scope Subdomains(Optional)</h4>
-                <span class="">You can import subdomains for <b>{{domain.name}}</b> using your private recon tools.</span>
-                <br>
-                <div class="alert bg-soft-warning border-0 mt-1 mb-1" role="alert">
-                  <span class="">Separate the out of scope subdomains/keywords using new line.(No regex currently supported.)</span>
+                <h4 class="text-warning">Out of Scope Subdomains (Optional)</h4>
+                <p>Specify subdomains of <strong>{{domain.name}}</strong> to exclude from scanning. These subdomains will be omitted from all subsequent scans, including URL discovery and vulnerability assessments.</p>
+                <p>Enter one subdomain or pattern per line. Both plain text and regex patterns are supported. <span class="badge bg-soft-primary text-primary ms-2">New</span></p>
+                <div class="mt-2 mb-2">
+                  <li>For plain text: <code>admin.example.com</code></li>
+                  <li>For regex: <code>^.*outofscope.*\.com$</code>, <code>admin.*</code> etc</li>
                 </div>
                 <label for="outOfScopeSubdomainTextarea" class="form-label mt-1">Out of Scope Subdomains List</label>
-                <textarea class="form-control" id="outOfScopeSubdomainTextarea" name="outOfScopeSubdomainTextarea" rows="6" spellcheck="false"></textarea>
+                <textarea class="form-control" id="outOfScopeSubdomainTextarea" name="outOfScopeSubdomainTextarea" rows="6" spellcheck="false" placeholder="Enter subdomains or patterns, one per line"></textarea>
               </div>
             </div>
 


### PR DESCRIPTION
This PR has improved system for checking out-of-scope subdomains in reNgine's subdomain discovery process. 

The new implementation supports both regex and plain text patterns.

> Introduced a new SubdomainChecker utility class
> Updated the subdomain discovery Celery task to use the new checker
> Updated the save_subdomain function to use new out of scope checker
> Supports both regex and plain text patterns




