### PR TITLE
Update of the uninstall.sh script

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -30,8 +30,8 @@ read -p "$(echo -e ${WARNING}"Are you sure you want to proceed? (y/Y/yes/YES to 
 # change answer to lowecase for comparison
 ANSWER_LC=$(echo "$CONFIRM" | tr '[:upper:]' '[:lower:]')
 
-if [[ "$ANSWER_LC" != "y" && "$ANSWER_LC" != "yes" ]]; then
-    print_status "${YELLOW}Uninstall aborted by user.${RESET}"
+if [ -z "$CONFIRM" ] || { [ "$CONFIRM" != "y" ] && [ "$CONFIRM" != "Y" ] && [ "$CONFIRM" != "yes" ] && [ "$CONFIRM" != "Yes" ] && [ "$CONFIRM" != "YES" ]; }; then
+    print_status "${WARNING}Uninstall aborted by user.${RESET}"
     exit 0
 fi
 


### PR DESCRIPTION
TLDR; Script updated to abort uninstall process if anything other than the specified:  "y/Y/Yes/yes/YES" is entered. Fixes uninstall on user inputs like "no" or blank input.
____
The uninstall.sh script does not abort if any user input is provided.

Command used:
`sudo sh uninstall.sh`

The following user-input scenarios were tested, confirmed and fixed:
- no input
- "n" 
- "N"
- "No"
- "1"
- "q"
- "
- (
- '
- <
- [
- {
- /