### PR TITLE
feat:  Prefll the scan parameters during rescan with the scan configuration values that were being used in earlier scan #1381 

### DIFF
--- a/web/startScan/static/startScan/js/start-scan-wizard-init.js
+++ b/web/startScan/static/startScan/js/start-scan-wizard-init.js
@@ -10,24 +10,32 @@ $("#select_engine").steps({
   onStepChanging: updateButton,
   labels: { finish: "Start Scan" },
   onInit: function (event, current) {
-    $(".actions ul li:nth-child(3) a").attr(
-      "onclick",
-      `$(this).closest('form').submit()`
+    $(".actions ul li:nth-child(3) a")
+      .attr("onclick", `$(this).closest('form').submit()`)
+      .addClass("text-white");
+    $(".actions ul li:nth-child(1) a[href='#previous']").removeClass(
+      "btn btn-primary waves-effect waves-light"
     );
+    disableNext();
+    updateButton();
+    updatePreviousButton();
   },
 });
+
 $("input[type=radio][name=scan_mode]").change(initTimer).keyup(initTimer);
-disableNext();
-$('a[role="menuitem"]').addClass("text-white");
+// $('a[role="menuitem"]').addClass("text-white");
 
 function initTimer() {
   if (globalTimeout) clearTimeout(globalTimeout);
   globalTimeout = setTimeout(updateButton, 400);
 }
+
 function disableNext() {
   var nextButton = $(".actions ul li:nth-child(2) a");
   nextButton.attr("href", "#");
-  buttonEnabled = $(".actions ul li:nth-child(2)")
+  nextButton.removeClass("btn btn-primary waves-effect waves-light text-white");
+  buttonEnabled = false;
+  $(".actions ul li:nth-child(2)")
     .addClass("disabled")
     .attr("aria-disabled", "true");
 }
@@ -35,22 +43,36 @@ function disableNext() {
 function enableNext() {
   var nextButton = $(".actions ul li:nth-child(2) a");
   nextButton.attr("href", "#next");
-  buttonEnabled = $(".actions ul li:nth-child(2)")
+  buttonEnabled = true;
+  nextButton.addClass("btn btn-primary waves-effect waves-light text-white");
+  $(".actions ul li:nth-child(2)")
     .removeClass("disabled")
     .attr("aria-disabled", "false");
 }
 
 function updateButton() {
-  $('a[role="menuitem"]').addClass("btn btn-primary waves-effect waves-light");
-  var text = $("input[type=radio][name=scan_mode]").val();
-  if (text === "") {
-    disableNext();
-    return false;
-  } else {
+  var selectedEngine = $("input[type=radio][name=scan_mode]:checked").val();
+  if (selectedEngine) {
     enableNext();
-    return true;
+  } else {
+    disableNext();
+  }
+  updatePreviousButton();
+  return buttonEnabled;
+}
+
+function updatePreviousButton() {
+  var previousButton = $("a[href='#previous']");
+  if (previousButton.parent().hasClass("disabled")) {
+    previousButton.removeClass("text-white");
+  } else {
+    previousButton.addClass("text-white");
   }
 }
+
+$("#select_engine").on("steps.change", function (e, currentIndex, newIndex) {
+  setTimeout(updatePreviousButton, 0);
+});
 
 $("#excludedPaths").selectize({
   persist: false,

--- a/web/startScan/templates/startScan/_items/scanengine_accordion.html
+++ b/web/startScan/templates/startScan/_items/scanengine_accordion.html
@@ -4,7 +4,7 @@
       <h2 class="accordion-header" id="heading_{{engine.id}}">
         <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse_{{engine.id}}" aria-expanded="false" aria-controls="collapse_{{engine.id}}">
           <div class="form-check form-check-primary">
-            <input class="form-check-input rounded-circle" type="radio" id="accordion_{{engine.id}}" name="scan_mode" value="{{engine.id}}" required>
+            <input class="form-check-input rounded-circle" type="radio" id="accordion_{{engine.id}}" name="scan_mode" value="{{engine.id}}" required {% if engine.id == selected_engine_id %}checked{% endif %}>
             <label class="form-check-label lead" for="accordion_{{engine.id}}">{{engine.engine_name}}
               &nbsp;&nbsp;&nbsp;
               {% if engine.default_engine %}

--- a/web/startScan/templates/startScan/_items/start_scan_wizard.html
+++ b/web/startScan/templates/startScan/_items/start_scan_wizard.html
@@ -34,7 +34,12 @@
                   <span>Enter one subdomain per line. Subdomains not belonging to <strong>{{domain.name}}</strong> will be automatically skipped.</span>
                 </div>
                 <label for="importSubdomainFormControlTextarea" class="form-label mt-1">Subdomains List</label>
+                {% if subdomains_in %}
+                <textarea class="form-control" id="importSubdomainFormControlTextarea" name="importSubdomainTextArea" rows="6" spellcheck="false">{% for subdomain in subdomains_in %}{{ subdomain }}{% if not forloop.last %}
+{% endif %}{% endfor %}</textarea>
+                {% else %}
                 <textarea class="form-control" id="importSubdomainFormControlTextarea" name="importSubdomainTextArea" rows="6" spellcheck="false"></textarea>
+                {% endif %}
               </div>
               <div class="mb-3">
                 <h4 class="text-warning">Out of Scope Subdomains (Optional)</h4>
@@ -45,7 +50,12 @@
                   <li>For regex: <code>^.*outofscope.*\.com$</code>, <code>admin.*</code> etc</li>
                 </div>
                 <label for="outOfScopeSubdomainTextarea" class="form-label mt-1">Out of Scope Subdomains List</label>
-                <textarea class="form-control" id="outOfScopeSubdomainTextarea" name="outOfScopeSubdomainTextarea" rows="6" spellcheck="false" placeholder="Enter subdomains or patterns, one per line"></textarea>
+                {% if subdomains_out %}
+                <textarea class="form-control" id="outOfScopeSubdomainTextarea" name="importSubdomainTextArea" rows="6" spellcheck="false">{% for subdomain in subdomains_out %}{{ subdomain }}{% if not forloop.last %}
+{% endif %}{% endfor %}</textarea>
+                {% else %}
+                <textarea class="form-control" id="outOfScopeSubdomainTextarea" name="importSubdomainTextArea" rows="6" spellcheck="false" placeholder="Enter subdomains or patterns, one per line"></textarea>
+                {% endif %}
               </div>
             </div>
 
@@ -53,7 +63,11 @@
             <div class="mb-4">
               <div class="mb-3">
                 <h4 class="text-info">Starting Point Path (Optional)</h4>
-                <input type="email" class="form-control" id="startingPointPath" placeholder="e.g. /home" name="startingPointPath">
+                {% if starting_point_path %}
+                  <input type="email" class="form-control" id="startingPointPath" placeholder="e.g. /home" name="startingPointPath" value="{{starting_point_path}}">
+                {% else %}
+                  <input type="email" class="form-control" id="startingPointPath" placeholder="e.g. /home" name="startingPointPath">
+                {% endif %}
                 <small class="form-text text-muted">
                   Defines where the scan should begin. Leave blank to scan from the root (/) and include all subdomains. 
                   </br>

--- a/web/startScan/templates/startScan/history.html
+++ b/web/startScan/templates/startScan/history.html
@@ -180,8 +180,9 @@ Quick Scan History
                         <a class="dropdown-item text-primary" href="javascript:show_scan_configuration('{{scan_history.cfg_starting_point_path}}', {{scan_history.cfg_out_of_scope_subdomains}}, {{scan_history.cfg_excluded_paths}}, {{scan_history.cfg_imported_subdomains}})"><i class="fe-settings"></i>&nbsp;Show Configurations</a>
                         {% if user|can:'initiate_scans_subscans' %}
                           {% if scan_history.scan_status == 0 or scan_history.scan_status == 2 or scan_history.scan_status == 3 %}
-                          <a class="dropdown-item text-primary" href="/scan/{{current_project.slug}}/start/{{scan_history.domain.id}}">
-                          <i class="fe-refresh-ccw"></i>&nbsp;Rescan </a>
+                          <a class="dropdown-item text-primary" href="{% url 'start_scan' current_project.slug scan_history.domain.id %}?rescan=true&history_id={{ scan_history.id }}">
+                            <i class="fe-refresh-ccw"></i>&nbsp;Rescan
+                          </a>
                           {% endif %}
 
                           {% if scan_history.scan_status == 1 or scan_history.scan_status == -1%}


### PR DESCRIPTION
This PR introduces prefilling scan parameters such as selecting the same scan engine used earlier, same imported subdomains, out-of-scope, paths, etc during rescan. This improved the user experience during the rescan of the same target