### PR TITLE
Replace CVE-2024-41661 with CVE-2023-50094

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Security Update
 
-* (Security) CVE-2024-41661 Stored Cross-Site Scripting (XSS) via DNS Record Poisoning reported by @touhidshaikh Advisory https://github.com/yogeshojha/rengine/security/advisories/GHSA-96q4-fj2m-jqf7
+* (Security) CVE-2023-50094 Stored Cross-Site Scripting (XSS) via DNS Record Poisoning reported by @touhidshaikh Advisory https://github.com/yogeshojha/rengine/security/advisories/GHSA-96q4-fj2m-jqf7
 
 ### Bug Fixes
 
@@ -31,7 +31,7 @@
 ## What's Changed
 
 ### Security update
-* (Security) CVE-2024-41661 Fix Authenticated command injection in WAF detection tool reported by @n-thumann Advisory https://github.com/yogeshojha/rengine/security/advisories/GHSA-fx7f-f735-vgh4
+* (Security) CVE-2023-50094 Fix Authenticated command injection in WAF detection tool reported by @n-thumann Advisory https://github.com/yogeshojha/rengine/security/advisories/GHSA-fx7f-f735-vgh4
 
 ### Bug Fixes
 


### PR DESCRIPTION
On 29 August 2024, MITRE informed GitHub that CVE-2024-41661, which was issued August 2024 is a duplicate of CVE-2023-50094, which was issued December 2023 or January 2024. We rejected CVE-2024-41661 as a duplicate CVE because CVE-2023-50094 was published first. I suggest that the maintainers of reNgine replace all instances of CVE-2024-41661 with CVE-2023-50094, including in the changelog and repository security advisory.