### PR TITLE
Fix Telegram Push Bug by Encoding # in URLs

### DIFF
--- a/web/reNgine/common_func.py
+++ b/web/reNgine/common_func.py
@@ -15,7 +15,7 @@ import xmltodict
 
 from time import sleep
 from bs4 import BeautifulSoup
-from urllib.parse import urlparse
+from urllib.parse import urlparse, quote
 from celery.utils.log import get_task_logger
 from discord_webhook import DiscordEmbed, DiscordWebhook
 from django.db.models import Q
@@ -593,6 +593,7 @@ def send_telegram_message(message):
 		return
 	telegram_bot_token = notif.telegram_bot_token
 	telegram_bot_chat_id = notif.telegram_bot_chat_id
+	message = quote(message)
 	send_url = f'https://api.telegram.org/bot{telegram_bot_token}/sendMessage?chat_id={telegram_bot_chat_id}&parse_mode=Markdown&text={message}'
 	requests.get(send_url)
 


### PR DESCRIPTION
**Description:** This pull request resolves an issue where the # character in messages was causing Telegram API requests to misinterpret everything after # as a URL fragment (hash), leading to incomplete or incorrect message delivery.

In URLs, the # symbol is used to denote the start of a fragment identifier, so when it appears unencoded in the message content, it causes the Telegram API to truncate or mishandle the message.


**Changes:**

Applied URL encoding to the message content using urllib.parse.quote to escape special characters like #. This ensures that the entire message, including text after #, is correctly transmitted to Telegram.

**Code Before:**

```python
send_url = f'https://api.telegram.org/bot{telegram_bot_token}/sendMessage?chat_id={telegram_bot_chat_id}&parse_mode=Markdown&text={message}'
```

**Code After:**

```python
message = quote(message)
send_url = f'https://api.telegram.org/bot{telegram_bot_token}/sendMessage?chat_id={telegram_bot_chat_id}&parse_mode=Markdown&text={message}'
```

By URL encoding the message, we ensure that characters like # are safely transmitted, preventing Telegram from misinterpreting them as hash fragments in URLs.