### PR TITLE
Uncontrolled data used in path expression

### DIFF
--- a/web/reNgine/views.py
+++ b/web/reNgine/views.py
@@ -6,7 +6,9 @@ from django.conf import settings
 
 @login_required
 def serve_protected_media(request, path):
-    file_path = os.path.join(settings.MEDIA_ROOT, path)
+    file_path = os.path.normpath(os.path.join(settings.MEDIA_ROOT, path))
+    if not file_path.startswith(settings.MEDIA_ROOT):
+         raise Http404("File not found")
     if os.path.isdir(file_path):
         raise Http404("File not found")
     if os.path.exists(file_path):
@@ -18,4 +20,3 @@ def serve_protected_media(request, path):
         return response
     else:
         raise Http404("File not found")
-


### PR DESCRIPTION
To fix the problem, we need to validate the `path` parameter to ensure it does not allow directory traversal and is contained within the `settings.MEDIA_ROOT` directory. We can achieve this by normalizing the path using `os.path.normpath` and then checking if the resulting path starts with `settings.MEDIA_ROOT`.

1. Normalize the `file_path` using `os.path.normpath`.
2. Check if the normalized `file_path` starts with `settings.MEDIA_ROOT`.
3. If the check fails, raise an `Http404` error.
4. If the check passes, proceed with the existing logic.