### PR TITLE
#1476-#1480-#1487 Fix, setting fallback for Nuclei variable and fixing JS errors in Vulnerabilities page

### DIFF
--- a/web/reNgine/tasks.py
+++ b/web/reNgine/tasks.py
@@ -3671,7 +3671,7 @@ def parse_nuclei_result(line):
 		'type': line['type'],
 		'severity': NUCLEI_SEVERITY_MAP[line['info'].get('severity', 'unknown')],
 		'template': line['template'],
-		'template_url': line['template-url'],
+		'template_url': line.get('template-url', []),
 		'template_id': line['template-id'],
 		'description': line['info'].get('description', ''),
 		'matcher_name': line.get('matcher-name', ''),

--- a/web/startScan/templates/startScan/detail_scan.html
+++ b/web/startScan/templates/startScan/detail_scan.html
@@ -1752,18 +1752,18 @@ $(document).ready(function() {
 								const encodedURLData = htmlEncode(data);
 								
 								if (data.toLowerCase().startsWith('http')) {
-									return `<a href="${encodedData}" 
+									return `<a href="${encodedURLData}" 
 											target="_blank" 
 											rel="noopener noreferrer" 
 											class="text-danger">
-											${split_into_lines(encodedData, 150)}
+											${split_into_lines(encodedURLData, 150)}
 										</a>`;
 								}
 							}
 							return htmlEncode(data || '');
 						},
 						"targets": 11,
-					}
+					},
 					{
 						"render": function ( data, type, row ) {
 							if (data){

--- a/web/startScan/templates/startScan/vulnerabilities.html
+++ b/web/startScan/templates/startScan/vulnerabilities.html
@@ -199,18 +199,18 @@ $(document).ready(function() {
 						const encodedURLData = htmlEncode(data);
 						
 						if (data.toLowerCase().startsWith('http')) {
-							return `<a href="${encodedData}" 
+							return `<a href="${encodedURLData}" 
 									target="_blank" 
 									rel="noopener noreferrer" 
 									class="text-danger">
-									${split_into_lines(encodedData, 150)}
+									${split_into_lines(encodedURLData, 150)}
 								</a>`;
 						}
 					}
 					return htmlEncode(data || '');
 				},
 				"targets": 11,
-			}
+			},
 			{
 				"render": function ( data, type, row ) {
 					if (data){

--- a/web/targetApp/templates/target/summary.html
+++ b/web/targetApp/templates/target/summary.html
@@ -1512,18 +1512,18 @@ $(document).ready(function(){
 						const encodedURLData = htmlEncode(data);
 						
 						if (data.toLowerCase().startsWith('http')) {
-							return `<a href="${encodedData}" 
+							return `<a href="${encodedURLData}" 
 									target="_blank" 
 									rel="noopener noreferrer" 
 									class="text-danger">
-									${split_into_lines(encodedData, 150)}
+									${split_into_lines(encodedURLData, 150)}
 								</a>`;
 						}
 					}
 					return htmlEncode(data || '');
 				},
 				"targets": 11,
-			}
+			},
 			{
 				"render": function(data, type, row) {
 					if (data) {


### PR DESCRIPTION
Adding fallback for template-url variable in tasks.py, fixing missing comma in vulnerability_table JS, fixing encodedURLData typo for vulnerability_table render function.

By setting a template-url fallback in tasks.py, we address the change in Nuclei requiring template-url to be provided, even as an empty array. This addresses Issue #1476 and issue #1480  and thanks to @Flv-cmd for the tasks.py snippet that was more elegant than my original fix. 

By adding the missing commas in the vulnerability table, and ensuring the right variable is referenced for the vulnerability data, we address issue #1487. 

Thank you for your review!
-David