### PR TITLE
fix checking for docker compose command in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -90,7 +90,7 @@ tput setaf 4;
 echo "#########################################################################"
 echo "Installing Docker Compose"
 echo "#########################################################################"
-if [ -x "$(command -v docker compose)" ]; then
+if (docker compose version &> /dev/null); then
   tput setaf 2; echo "Docker Compose already installed, skipping."
 else
   curl -L "https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose


### PR DESCRIPTION
🔍 Why Not Just command -v "docker compose"?

Because docker compose is not a standalone command, it's a subcommand of the docker binary.
docker compose is part of the Docker CLI.
command -v only works for standalone binaries (like docker, ls, curl).
So to test if the subcommand exists, you try running it and check the return status