### PR TITLE
Fix internal server error 500 during report generation

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -41,4 +41,4 @@ wafw00f==2.2.0
 xmltodict==0.13.0
 django-environ==0.11.2
 plotly==5.23.0
-kaleido
+kaleido==0.2.1


### PR DESCRIPTION
## Problem
- HTTP 500 internal server errors occurred when generating reports
- Root cause: Kaleido version 1.0.0 is incompatible with plotly==5.23.0
- The dependency was previously unpinned, allowing incompatible versions to be installed

## Solution
- Pin kaleido to version 0.2.1 in requirements.txt
- This version is confirmed compatible with plotly==5.23.0
- Ensures consistent behavior across all environments

## Changes
- Updated requirements.txt:
  - Before: `kaleido` (unpinned)
  - After: `kaleido==0.2.1` (pinned to compatible version)

This change resolves the server errors and ensures reliable report generation functionality.